### PR TITLE
fix: read sessionPrefix from config, remove unused maxSessionAgeMs

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -142,15 +142,17 @@ function createLinearTools(api: OpenClawPluginApi, ctx: any) {
 // ---------------------------------------------------------------------------
 
 async function onAgentEnd(api: OpenClawPluginApi, event: any) {
-  const sessionKey = event?.sessionKey as string | undefined;
-  if (!sessionKey?.startsWith("linear:")) return;
-
   const config = api.pluginConfig as Record<string, unknown> | undefined;
+  const sessionPrefix = (config?.sessionPrefix as string) || "linear:";
+
+  const sessionKey = event?.sessionKey as string | undefined;
+  if (!sessionKey?.startsWith(sessionPrefix)) return;
+
   const tokenInfo = resolveLinearToken(config);
   if (!tokenInfo.accessToken) return;
 
-  // Extract issue ID from session key: "linear:{issueId}"
-  const issueId = sessionKey.slice("linear:".length);
+  // Extract issue ID from session key: "{sessionPrefix}{issueId}"
+  const issueId = sessionKey.slice(sessionPrefix.length);
   if (!issueId) return;
 
   const linearApi = new LinearAgentApi(tokenInfo.accessToken, {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -41,11 +41,6 @@
         "type": "string",
         "description": "Prefix for session keys",
         "default": "linear:"
-      },
-      "maxSessionAgeMs": {
-        "type": "number",
-        "description": "Max age for issue sessions before starting fresh (default: 24h)",
-        "default": 86400000
       }
     }
   }

--- a/src/webhook-handler.ts
+++ b/src/webhook-handler.ts
@@ -223,7 +223,8 @@ async function handleSessionCreated(
   const issue = session.issue;
   const comment = session.comment;
   const issueId = issue.id;
-  const sessionKey = `linear:${issueId}`;
+  const sessionPrefix = (config?.sessionPrefix as string) || "linear:";
+  const sessionKey = `${sessionPrefix}${issueId}`;
 
   // Determine prompt content
   // If triggered by @mention, use the comment body
@@ -303,7 +304,8 @@ async function handleSessionPrompted(
   }
 
   const issueId = session.issue.id;
-  const sessionKey = `linear:${issueId}`;
+  const sessionPrefix = (config?.sessionPrefix as string) || "linear:";
+  const sessionKey = `${sessionPrefix}${issueId}`;
   const prompt = sanitizePromptInput(activity.content.body);
 
   const message = [


### PR DESCRIPTION
Assignee: @QiuYi111 ([qiuyi200311](https://linear.app/jingyi-dev/profiles/qiuyi200311))

## Summary

Fixes two config options in `openclaw.plugin.json` that were declared but never actually used:

- **`sessionPrefix`** was hardcoded as `"linear:"` in 3 locations — now reads from config with `"linear:"` fallback
- **`maxSessionAgeMs`** was never passed to the OpenClaw runtime — removed since session TTL is controlled by the runtime

## Implementation

- `src/webhook-handler.ts`: Read `sessionPrefix` from `config?.sessionPrefix` in `handleSessionCreated` (line 226) and `handleSessionPrompted` (line 307), replacing hardcoded `"linear:"` template literals
- `index.ts`: Read `sessionPrefix` from config in `onAgentEnd` (line 146), used for both `startsWith` filtering and `slice` extraction of the issue ID
- `openclaw.plugin.json`: Removed `maxSessionAgeMs` config property (session age is controlled by OpenClaw runtime, not the plugin)

## Testing

- Verified all 3 hardcoded `"linear:"` locations are replaced with config reads
- Verified fallback to `"linear:"` when config is unset
- Verified no remaining hardcoded `"linear:"` in session key contexts
- No test suite or node_modules available in project

## Breaking Changes

Users who set `maxSessionAgeMs` in their config will see it silently ignored (it was already a no-op). The option has been removed from the config schema.

Fixes DEV-69

---

> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a "changes requested" review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->