### PR TITLE
fix: implement handleCommentCreate fallback for comment-triggered sessions

### DIFF
--- a/src/webhook-handler.ts
+++ b/src/webhook-handler.ts
@@ -325,7 +325,9 @@ async function handleSessionPrompted(
 
 /**
  * Handle comment create events (fallback for non-agent-session setups)
- * If the comment contains the trigger text, treat it as a request
+ * If the comment contains the trigger text, treat it as a request.
+ * This path is used when Linear Agent Sessions are not available —
+ * the webhook receives Comment events directly instead of AgentSessionEvent.
  */
 async function handleCommentCreate(
   api: OpenClawPluginApi,
@@ -342,7 +344,62 @@ async function handleCommentCreate(
     return;
   }
 
-  // Already handled by AgentSessionEvent if agent sessions are enabled
-  // This is a fallback path
-  api.logger.debug(`Linear Light: comment trigger detected (fallback path), skipping — AgentSessionEvent should handle this`);
+  const issueId = comment.issue.id;
+  const sessionKey = `linear:${issueId}`;
+
+  api.logger.info(`Linear Light: comment trigger detected (fallback path) for issue ${issueId}`);
+
+  // Resolve Linear API to fetch full issue details and update status
+  const tokenInfo = resolveLinearToken(config);
+  if (!tokenInfo.accessToken) {
+    api.logger.warn("Linear Light: comment fallback triggered but no Linear API token available");
+    return;
+  }
+
+  const linearApi = new LinearAgentApi(tokenInfo.accessToken, {
+    refreshToken: tokenInfo.refreshToken,
+    expiresAt: tokenInfo.expiresAt,
+  });
+
+  let issue;
+  try {
+    issue = await linearApi.getIssueDetails(issueId);
+  } catch (err) {
+    api.logger.error(`Linear Light: failed to fetch issue ${issueId}: ${err}`);
+    return;
+  }
+
+  // Update issue status to In Progress
+  if (config?.autoInProgress !== false) {
+    try {
+      await linearApi.updateIssueState(issueId, "In Progress");
+      api.logger.info(`Linear Light: ${issue.identifier} → In Progress`);
+    } catch (err) {
+      api.logger.warn(`Linear Light: failed to update status: ${err}`);
+    }
+  }
+
+  // Build the message for the agent
+  const sanitizedPrompt = sanitizePromptInput(comment.body);
+
+  const message = [
+    `[Linear Issue ${issue.identifier}] ${issue.title}`,
+    issue.description ? `\n---\n${issue.description}` : "",
+    `\n---\n**User comment:**\n${sanitizedPrompt}`,
+    `\n---\nIssue URL: ${issue.url}`,
+    `\nUse linear_comment() to reply on the issue, linear_update_status() to change status.`,
+    `\nWhen done, update status to "Done" and I'll notify the user for review.`,
+  ].join("\n");
+
+  // Dispatch to OpenClaw agent with session key for continuity
+  await api.runAgent({
+    message,
+    sessionKey,
+    agentId: "main",
+    name: "Linear",
+    wakeMode: "now",
+    deliver: false,
+  });
+
+  api.logger.info(`Linear Light: dispatched agent for ${issue.identifier} (comment fallback)`);
 }


### PR DESCRIPTION
Assignee: @QiuYi111 ([Yi Qiu](https://linear.app/jingyi-dev/profiles/qiuyi200311))

## Summary

Fix dead-code fallback in `handleCommentCreate()` that silently dropped all @mention-triggered agent sessions when Linear Agent Sessions were unavailable. The function now properly dispatches agent sessions, matching `handleSessionCreated` behavior.

## Problem

`handleCommentCreate()` was registered as a fallback for setups where `AgentSessionEvent` is not available (e.g., lower Linear plans or Comment-only webhook subscriptions), but the function body only logged a debug message and returned. Every @mention was silently ignored with no error or warning.

## Implementation

Replaced the no-op fallback with a full implementation that:

- Resolves the Linear API token and fetches full issue details via `getIssueDetails()` (the comment payload only contains `issue.id`, not the full issue object)
- Updates issue status to "In Progress" (respecting `autoInProgress` config)
- Builds an agent prompt with issue context + the triggering comment body
- Dispatches the agent via `api.runAgent()` with `sessionKey: linear:{issueId}` for session continuity

The fallback path is now functionally identical to `handleSessionCreated`, adapted for the `Comment/create` webhook payload shape.

## Testing

- Verified code follows existing `handleSessionCreated` patterns exactly
- No test framework configured in this project; no tests to run
- No `node_modules` available for typecheck

Closes DEV-72

---

> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a "changes requested" review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->