### PR TITLE
fix: log GraphQL partial errors instead of silently discarding them

### DIFF
--- a/src/api/linear-api.ts
+++ b/src/api/linear-api.ts
@@ -104,8 +104,11 @@ export class LinearAgentApi {
     }
 
     const payload = await res.json();
-    if (payload.errors?.length && !payload.data) {
-      throw new Error(`Linear GraphQL: ${JSON.stringify(payload.errors)}`);
+    if (payload.errors?.length) {
+      console.warn(`Linear GraphQL partial errors: ${JSON.stringify(payload.errors)}`);
+      if (!payload.data) {
+        throw new Error(`Linear GraphQL: ${JSON.stringify(payload.errors)}`);
+      }
     }
 
     return payload.data as T;


### PR DESCRIPTION
Assignee: @QiuYi111 ([qiuyi200311](https://linear.app/jingyi-dev/profiles/qiuyi200311))

## Summary

- Fixed GraphQL error handling in `LinearAgentApi.gql()` to log partial errors (where `data` is present alongside `errors`) instead of silently discarding them
- Previously, errors were only thrown when no data was returned, causing misleading downstream errors (e.g., "Cannot find team for issue" when the real cause was a permission error on a nested field)

## Implementation

Changed the error guard in `src/api/linear-api.ts` from:
```ts
if (payload.errors?.length && !payload.data) {
  throw new Error(...);
}
```
to:
```ts
if (payload.errors?.length) {
  console.warn(`Linear GraphQL partial errors: ${JSON.stringify(payload.errors)}`);
  if (!payload.data) {
    throw new Error(...);
  }
}
```

This ensures all GraphQL errors are surfaced via `console.warn`, while preserving the existing throw behavior when no usable data is returned.

## Testing

- Type checking passes (no new errors)
- Change is minimal and follows the pattern suggested in the issue

Closes DEV-73. Fixes #24.

---

> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a "changes requested" review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->