### PR TITLE
fix: dedup key falls back to createdAt for AgentSessionEvents

### DIFF
--- a/src/webhook-handler.ts
+++ b/src/webhook-handler.ts
@@ -136,8 +136,12 @@ export async function handleWebhook(
     return;
   }
 
-  // Dedup
-  const dedupKey = `${body.type}:${body.action}:${body.data?.id || body.createdAt}`;
+  // Dedup — use payload-type-aware ID
+  const eventId =
+    body.agentSession?.id || // AgentSessionEvent
+    body.data?.id || // Comment / Issue
+    body.createdAt;
+  const dedupKey = `${body.type}:${body.action}:${eventId}`;
   if (wasRecentlyProcessed(dedupKey)) {
     res.writeHead(200, { "Content-Type": "application/json" });
     res.end(JSON.stringify({ ok: true, deduped: true }));


### PR DESCRIPTION
Assignee: @QiuYi111 ([qiuyi200311](https://linear.app/jingyi-dev/profiles/qiuyi200311))

## Summary

Fixes a bug where the webhook dedup key in `src/webhook-handler.ts` fell back to `body.createdAt` for `AgentSessionEvent` payloads, breaking deduplication.

For `AgentSessionEvent` payloads, the session data lives under `body.agentSession`, not `body.data`. The old code `body.data?.id || body.createdAt` always resolved to `body.createdAt` for these payloads, causing:

1. **False dedup drops** — two different events delivered in the same second shared the same key
2. **Missed dedup** — retry deliveries of the same event at different times got different keys

## Fix

Use a payload-type-aware ID chain:

```ts
const eventId =
  body.agentSession?.id || // AgentSessionEvent
  body.data?.id ||          // Comment / Issue
  body.createdAt;
```

## Testing

- Verified no new type errors introduced on changed lines
- Existing 9 pre-existing type errors on other files unchanged
- No test suite in project

Closes DEV-65, closes #16

---

> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a "changes requested" review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->