### PR TITLE
fix: use refreshToken presence for Bearer prefix in authHeader()

### DIFF
--- a/src/api/linear-api.ts
+++ b/src/api/linear-api.ts
@@ -79,10 +79,8 @@ export class LinearAgentApi {
   }
 
   private authHeader(): string {
-    // Cyrus tokens (lin_oauth_*) use Bearer prefix
-    return this.accessToken.startsWith("lin_")
-      ? this.accessToken
-      : `Bearer ${this.accessToken}`;
+    // OAuth tokens require Bearer prefix; personal API keys do not
+    return this.refreshToken ? `Bearer ${this.accessToken}` : this.accessToken;
   }
 
   private async gql<T = unknown>(


### PR DESCRIPTION
Assignee: @QiuYi111 ([qiuyi200311](https://linear.app/jingyi-dev/profiles/qiuyi200311))

## Summary

Fix `authHeader()` in `LinearAgentApi` to correctly determine when to add the `Bearer` prefix to the `Authorization` header.

## Problem

The previous implementation used `startsWith("lin_")` to decide whether to add `Bearer`:

```ts
return this.accessToken.startsWith("lin_")
  ? this.accessToken
  : `Bearer ${this.accessToken}`;
```

Both Linear token types start with `lin_`:
- **Personal API keys**: `lin_api_…` — no `Bearer` prefix needed
- **OAuth tokens**: `lin_oauth_…` — require `Bearer` prefix

This caused all OAuth-based authentication to fail with 401 errors.

## Fix

Replace the `startsWith("lin_")` heuristic with a `refreshToken` presence check, matching the upstream `openclaw-linear-plugin` reference implementation:

```ts
return this.refreshToken ? `Bearer ${this.accessToken}` : this.accessToken;
```

OAuth tokens are always issued with a refresh token; personal API keys never have one — making this a reliable discriminator.

## Testing

- Verified the fix matches the upstream reference implementation
- No test suite or lint config exists in this project
- No new TypeScript errors introduced (9 pre-existing errors are unrelated)

Closes DEV-62

---

> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a "changes requested" review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->