### PR TITLE
fix: wire up emitActivity so Linear agent sessions show progress

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -12,10 +12,9 @@
  * - cyrus linear-event-transport: webhook verification, message translation
  */
 
-import { createHmac, timingSafeEqual } from "node:crypto";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { resolveLinearToken, LinearAgentApi } from "./api/linear-api.js";
-import { handleWebhook } from "./webhook-handler.js";
+import { handleWebhook, agentSessionMap } from "./webhook-handler.js";
 
 export default function register(api: OpenClawPluginApi) {
   const config = api.pluginConfig as Record<string, unknown> | undefined;
@@ -84,11 +83,31 @@ function createLinearTools(api: OpenClawPluginApi, ctx: any) {
         required: ["issueId", "body"],
       },
       execute: async ({ issueId, body }: { issueId: string; body: string }) => {
+        const agentSessionId = agentSessionMap.get(issueId);
         try {
           await linearApi.createComment(issueId, body);
+
+          // Emit response activity so Linear shows progress
+          if (agentSessionId) {
+            try {
+              await linearApi.emitActivity(agentSessionId, { type: "response", body });
+            } catch (activityErr) {
+              api.logger.warn(`Linear Light: failed to emit activity: ${activityErr}`);
+            }
+          }
+
           return `Comment posted on issue ${issueId}`;
         } catch (err) {
-          return `Failed to comment: ${err instanceof Error ? err.message : String(err)}`;
+          const msg = err instanceof Error ? err.message : String(err);
+
+          // Emit error activity
+          if (agentSessionId) {
+            try {
+              await linearApi.emitActivity(agentSessionId, { type: "error", body: `Failed to comment: ${msg}` });
+            } catch {}
+          }
+
+          return `Failed to comment: ${msg}`;
         }
       },
     },
@@ -160,6 +179,16 @@ async function onAgentEnd(api: OpenClawPluginApi, event: any) {
 
   const success = event?.success !== false;
 
+  // Emit error activity if session failed
+  if (!success) {
+    const agentSessionId = agentSessionMap.get(issueId);
+    if (agentSessionId) {
+      try {
+        await linearApi.emitActivity(agentSessionId, { type: "error", body: "Agent session failed" });
+      } catch {}
+    }
+  }
+
   try {
     if (success && config?.notifyOnComplete !== false) {
       // Update status to Done
@@ -184,5 +213,7 @@ async function onAgentEnd(api: OpenClawPluginApi, event: any) {
     }
   } catch (err) {
     api.logger.error(`Linear Light: onAgentEnd failed for ${issueId}: ${err}`);
+  } finally {
+    agentSessionMap.delete(issueId);
   }
 }

--- a/src/webhook-handler.ts
+++ b/src/webhook-handler.ts
@@ -16,6 +16,9 @@ import { sanitizePromptInput } from "./utils.js";
 
 // Dedup tracking
 const recentlyProcessed = new Map<string, number>();
+
+// Maps issueId → Linear agent session ID, so tools can emit activity updates
+export const agentSessionMap = new Map<string, string>();
 const DEDUP_TTL_MS = 60_000;
 let lastSweep = Date.now();
 
@@ -235,22 +238,28 @@ async function handleSessionCreated(
     ? commentBody
     : issue.description || issue.title;
 
+  // Store agent session ID for activity emission
+  const agentSessionId = session.id as string | undefined;
+  if (agentSessionId) {
+    agentSessionMap.set(issueId, agentSessionId);
+  }
+
   api.logger.info(
     `Linear Light: session created for ${issue.identifier} (${isMentionTriggered ? "mention" : "auto"})`,
   );
 
+  // Resolve Linear API for status update and activity emission
+  const tokenInfo = resolveLinearToken(config);
+
   // Update issue status to In Progress
-  if (config?.autoInProgress !== false) {
+  if (config?.autoInProgress !== false && tokenInfo.accessToken) {
     try {
-      const tokenInfo = resolveLinearToken(config);
-      if (tokenInfo.accessToken) {
-        const linearApi = new LinearAgentApi(tokenInfo.accessToken, {
-          refreshToken: tokenInfo.refreshToken,
-          expiresAt: tokenInfo.expiresAt,
-        });
-        await linearApi.updateIssueState(issueId, "In Progress");
-        api.logger.info(`Linear Light: ${issue.identifier} → In Progress`);
-      }
+      const linearApi = new LinearAgentApi(tokenInfo.accessToken, {
+        refreshToken: tokenInfo.refreshToken,
+        expiresAt: tokenInfo.expiresAt,
+      });
+      await linearApi.updateIssueState(issueId, "In Progress");
+      api.logger.info(`Linear Light: ${issue.identifier} → In Progress`);
     } catch (err) {
       api.logger.warn(`Linear Light: failed to update status: ${err}`);
     }
@@ -278,6 +287,22 @@ async function handleSessionCreated(
     deliver: false,
   });
 
+  // Emit initial activity so Linear shows the session as active
+  if (agentSessionId && tokenInfo.accessToken) {
+    try {
+      const linearApi = new LinearAgentApi(tokenInfo.accessToken, {
+        refreshToken: tokenInfo.refreshToken,
+        expiresAt: tokenInfo.expiresAt,
+      });
+      await linearApi.emitActivity(agentSessionId, {
+        type: "thought",
+        body: `Starting work on ${issue.identifier}: ${issue.title}`,
+      });
+    } catch (err) {
+      api.logger.warn(`Linear Light: failed to emit initial activity: ${err}`);
+    }
+  }
+
   api.logger.info(`Linear Light: dispatched agent for ${issue.identifier}`);
 }
 
@@ -304,6 +329,12 @@ async function handleSessionPrompted(
 
   const issueId = session.issue.id;
   const sessionKey = `linear:${issueId}`;
+
+  // Ensure agent session ID is available for activity emission
+  const agentSessionId = session.id as string | undefined;
+  if (agentSessionId) {
+    agentSessionMap.set(issueId, agentSessionId);
+  }
   const prompt = sanitizePromptInput(activity.content.body);
 
   const message = [


### PR DESCRIPTION
Assignee: @QiuYi111 ([qiuyi200311](https://linear.app/jingyi-dev/profiles/qiuyi200311))

## Summary

Fixes #18 — Linear agent sessions were stuck in "pending" state because `emitActivity` was implemented but never called.

## Changes

- **`src/webhook-handler.ts`**: Added `agentSessionMap` (issueId → agentSessionId) to share session IDs with tools. Store `session.id` in both `handleSessionCreated` and `handleSessionPrompted`. Emit `"thought"` activity after agent dispatch to show the session is active.
- **`index.ts`**: Import `agentSessionMap`. In `linear_comment` tool, emit `"response"` activity on success and `"error"` activity on failure. In `onAgentEnd`, emit `"error"` activity if session failed. Clean up map entries in `finally` block.

## Implementation approach

The core challenge was that tools (`linear_comment`, etc.) had no access to the Linear agent session ID needed for the `agentActivityCreate` mutation. Solved with a module-level `Map<string, string>` shared between the webhook handler (which receives `session.id` from Linear's webhook payload) and the tools (which look it up by `issueId`).

Activity emission is best-effort — failures are logged but never block the primary workflow.

---

> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a "changes requested" review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->