### PR TITLE
fix: use raw buffer for HMAC signature verification

### DIFF
--- a/src/webhook-handler.ts
+++ b/src/webhook-handler.ts
@@ -51,7 +51,7 @@ function verifySignature(rawBody: Buffer, signature: string, secret: string): bo
 /**
  * Read JSON body from request (Node.js IncomingMessage style)
  */
-async function readBody(req: any, maxBytes = 1_000_000): Promise<{ ok: boolean; body?: any; raw?: string; error?: string }> {
+async function readBody(req: any, maxBytes = 1_000_000): Promise<{ ok: boolean; body?: any; rawBuffer?: Buffer; error?: string }> {
   return new Promise((resolve) => {
     const chunks: Buffer[] = [];
     let total = 0;
@@ -80,8 +80,8 @@ async function readBody(req: any, maxBytes = 1_000_000): Promise<{ ok: boolean; 
       settled = true;
       clearTimeout(timer);
       try {
-        const raw = Buffer.concat(chunks).toString("utf8");
-        resolve({ ok: true, body: JSON.parse(raw), raw });
+        const rawBuffer = Buffer.concat(chunks);
+        resolve({ ok: true, body: JSON.parse(rawBuffer.toString("utf8")), rawBuffer });
       } catch {
         resolve({ ok: false, error: "invalid json" });
       }
@@ -122,14 +122,14 @@ export async function handleWebhook(
     return;
   }
 
-  const { ok, body, raw, error } = await readBody(req);
-  if (!ok || !raw) {
+  const { ok, body, rawBuffer, error } = await readBody(req);
+  if (!ok || !rawBuffer) {
     res.writeHead(400, { "Content-Type": "application/json" });
     res.end(JSON.stringify({ error: error || "bad request" }));
     return;
   }
 
-  if (!verifySignature(Buffer.from(raw), signature, secret)) {
+  if (!verifySignature(rawBuffer, signature, secret)) {
     api.logger.warn("Linear Light: invalid webhook signature");
     res.writeHead(401, { "Content-Type": "application/json" });
     res.end(JSON.stringify({ error: "invalid signature" }));


### PR DESCRIPTION
Assignee: @QiuYi111 ([qiuyi200311](https://linear.app/jingyi-dev/profiles/qiuyi200311))

## Summary
- Fix potential HMAC signature corruption by keeping the raw `Buffer` from `readBody()` instead of round-tripping through a UTF-8 string
- `verifySignature` now receives the original bytes directly, eliminating the `Buffer → string → Buffer` conversion that could alter byte sequences for non-ASCII payloads

## Implementation
In `readBody()`, the raw body bytes are now stored as a `Buffer` (`rawBuffer`) and returned alongside the parsed JSON body. Previously, the bytes were converted to a UTF-8 string (`raw`) and later reconstructed via `Buffer.from(raw)` for signature verification — a round-trip that is not byte-identical for inputs containing multi-byte or invalid UTF-8 sequences.

Changes in `src/webhook-handler.ts`:
- `readBody()` return type: `raw?: string` → `rawBuffer?: Buffer`
- Body concatenation: store `Buffer.concat(chunks)` directly instead of calling `.toString("utf8")` on it
- Signature verification: pass `rawBuffer` directly to `verifySignature()` instead of `Buffer.from(raw)`

## Testing
- TypeScript type checking passes (no new errors introduced)
- Pre-existing type errors in `index.ts` are unrelated to this change

Closes #22

---

> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a "changes requested" review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->