### PR TITLE
fix: remove non-existent prompts.yaml from package.json files

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "index.ts",
     "src/",
     "openclaw.plugin.json",
-    "prompts.yaml",
     "README.md"
   ],
   "scripts": {


### PR DESCRIPTION
Assignee: @QiuYi111 ([qiuyi200311](https://linear.app/jingyi-dev/profiles/qiuyi200311))

## Summary

- Remove `prompts.yaml` from the `files` array in `package.json` — the file does not exist in the repository

## Problem

`package.json` listed `prompts.yaml` in the `files` array, but the file was never created. When the package is published to npm, the file will be absent, which could cause issues if OpenClaw's plugin loader tries to resolve it.

## Fix

Removed the non-existent `prompts.yaml` entry from the `files` array since no prompts file is needed for this plugin.

Closes DEV-68

---

> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a "changes requested" review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->