### PR TITLE
fix: sanitize issue.title and issue.description in agent prompt

### DIFF
--- a/src/webhook-handler.ts
+++ b/src/webhook-handler.ts
@@ -257,11 +257,13 @@ async function handleSessionCreated(
   }
 
   // Build the message for the agent
+  const safeTitle = sanitizePromptInput(issue.title, 200);
+  const safeDescription = issue.description ? sanitizePromptInput(issue.description) : "";
   const sanitizedPrompt = sanitizePromptInput(prompt);
 
   const message = [
-    `[Linear Issue ${issue.identifier}] ${issue.title}`,
-    issue.description ? `\n---\n${issue.description}` : "",
+    `[Linear Issue ${issue.identifier}] ${safeTitle}`,
+    safeDescription ? `\n---\n${safeDescription}` : "",
     isMentionTriggered ? `\n---\n**User comment:**\n${sanitizedPrompt}` : "",
     `\n---\nIssue URL: ${issue.url}`,
     `\nUse linear_comment() to reply on the issue, linear_update_status() to change status.`,


### PR DESCRIPTION
Assignee: @QiuYi111 ([qiuyi200311](https://linear.app/jingyi-dev/profiles/qiuyi200311))

## Summary

- Pass `issue.title` and `issue.description` through `sanitizePromptInput()` before embedding in the agent prompt
- Title is truncated to 200 chars; description uses the default 4000 char limit
- Prevents template variable injection (`{{...}}`) and token budget abuse from user-controlled issue metadata

## Implementation

In `src/webhook-handler.ts`, `handleSessionCreated()` now sanitizes both `issue.title` (with `maxLength=200`) and `issue.description` (with default `maxLength=4000`) using the existing `sanitizePromptInput()` utility, which handles truncation and `{{`/`}}` escaping.

```ts
const safeTitle = sanitizePromptInput(issue.title, 200);
const safeDescription = issue.description ? sanitizePromptInput(issue.description) : "";
```

## Testing

- TypeScript compilation passes (pre-existing errors in unrelated files remain unchanged)
- No test files exist in the project

## Breaking Changes

None.

Closes DEV-63

---

> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a "changes requested" review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->