### PR TITLE
feat: integrate 5 draft PRs and fix clearActiveRun prefix bug

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -14,7 +14,7 @@
 
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk"
 import { LinearAgentApi, resolveLinearToken } from "./src/api/linear-api.js"
-import { clearActiveRun, handleWebhook } from "./src/webhook-handler.js"
+import { agentSessionMap, clearActiveRun, handleWebhook } from "./src/webhook-handler.js"
 
 export default function register(api: OpenClawPluginApi) {
   const config = api.pluginConfig as Record<string, unknown> | undefined
@@ -90,12 +90,32 @@ function createLinearTools(api: OpenClawPluginApi): any[] {
         required: ["issueId", "body"],
       },
       execute: async (_toolCallId: string, { issueId, body }: { issueId: string; body: string }) => {
+        const agentSessionId = agentSessionMap.get(issueId)
         try {
           await linearApi.createComment(issueId, body)
+
+          // Emit response activity so Linear shows progress
+          if (agentSessionId) {
+            try {
+              await linearApi.emitActivity(agentSessionId, { type: "response", body })
+            } catch (activityErr) {
+              api.logger.warn(`Linear Light: failed to emit activity: ${activityErr}`)
+            }
+          }
+
           return { content: [{ type: "text", text: `Comment posted on issue ${issueId}` }], details: {} }
         } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err)
+
+          // Emit error activity
+          if (agentSessionId) {
+            try {
+              await linearApi.emitActivity(agentSessionId, { type: "error", body: `Failed to comment: ${msg}` })
+            } catch {}
+          }
+
           return {
-            content: [{ type: "text", text: `Failed to comment: ${err instanceof Error ? err.message : String(err)}` }],
+            content: [{ type: "text", text: `Failed to comment: ${msg}` }],
             details: { status: "failed" },
           }
         }
@@ -177,7 +197,7 @@ async function onSubagentEnded(api: OpenClawPluginApi, event: any): Promise<void
   if (!issueId) return
 
   // Clear the active run guard
-  clearActiveRun(sessionKey)
+  clearActiveRun(sessionKey, sessionPrefix)
 
   const linearApi = new LinearAgentApi(tokenInfo.accessToken, {
     refreshToken: tokenInfo.refreshToken,
@@ -188,6 +208,16 @@ async function onSubagentEnded(api: OpenClawPluginApi, event: any): Promise<void
   })
 
   const success = event?.success !== false
+
+  // Emit error activity if session failed
+  if (!success) {
+    const agentSessionId = agentSessionMap.get(issueId)
+    if (agentSessionId) {
+      try {
+        await linearApi.emitActivity(agentSessionId, { type: "error", body: "Agent session failed" })
+      } catch {}
+    }
+  }
 
   try {
     if (success) {
@@ -218,5 +248,7 @@ async function onSubagentEnded(api: OpenClawPluginApi, event: any): Promise<void
     }
   } catch (err) {
     api.logger.error(`Linear Light: onSubagentEnded failed for ${issueId}: ${err}`)
+  } finally {
+    agentSessionMap.delete(issueId)
   }
 }

--- a/src/__test__/fixtures.ts
+++ b/src/__test__/fixtures.ts
@@ -51,20 +51,6 @@ export function makeAgentSessionPrompted(overrides?: Record<string, unknown>) {
   }
 }
 
-export function makeCommentCreate(overrides?: Record<string, unknown>) {
-  return {
-    type: "Comment",
-    action: "create",
-    createdAt: "2026-04-01T12:01:00.000Z",
-    data: {
-      id: "comment-001",
-      body: "@Linus please help",
-      issue: { id: "issue-uuid-001" },
-    },
-    ...overrides,
-  }
-}
-
 // ---------------------------------------------------------------------------
 // Linear API response factories
 // ---------------------------------------------------------------------------
@@ -100,80 +86,6 @@ export function makeTeamStates() {
       },
     },
   }
-}
-
-// ---------------------------------------------------------------------------
-// Mock OpenClaw Plugin API
-// ---------------------------------------------------------------------------
-
-export function makeMockApi(overrides?: Record<string, unknown>) {
-  const mockLogger = {
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-    debug: vi.fn(),
-  }
-
-  const mockRunAgent = vi.fn().mockResolvedValue(undefined)
-  const mockSendNotification = vi.fn().mockResolvedValue(undefined)
-  const mockRegisterHttpRoute = vi.fn()
-  const mockRegisterTool = vi.fn()
-  const mockRegisterHook = vi.fn()
-
-  return {
-    pluginConfig: {
-      enabled: true,
-      webhookSecret: "test-webhook-secret",
-      mentionTrigger: "Linus",
-      autoInProgress: true,
-      notifyOnComplete: true,
-      notificationChannel: "telegram",
-      notificationTarget: "123456",
-      linearClientId: "test-client-id",
-      linearClientSecret: "test-client-secret",
-    } as Record<string, unknown>,
-    logger: mockLogger,
-    registerHttpRoute: mockRegisterHttpRoute,
-    registerTool: mockRegisterTool,
-    registerHook: mockRegisterHook,
-    runAgent: mockRunAgent,
-    sendNotification: mockSendNotification,
-    ...overrides,
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Mock HTTP req/res for webhook handler tests
-// ---------------------------------------------------------------------------
-
-export function makeMockReqRes(body: string, headers: Record<string, string> = {}) {
-  const chunks: Buffer[] = [Buffer.from(body)]
-  const res = {
-    _statusCode: 0,
-    _headers: {} as Record<string, string>,
-    _body: "",
-    writeHead: vi.fn((code: number, headers?: Record<string, string>) => {
-      res._statusCode = code
-      if (headers) Object.assign(res._headers, headers)
-    }),
-    end: vi.fn((data?: string) => {
-      if (data) res._body = data
-    }),
-  }
-
-  const req = {
-    headers: { "linear-signature": "test-sig", ...headers },
-    on: vi.fn((event: string, cb: (...args: any[]) => void) => {
-      if (event === "data") {
-        for (const chunk of chunks) cb(chunk)
-      }
-      if (event === "end") {
-        cb()
-      }
-    }),
-  }
-
-  return { req, res }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/__test__/index.test.ts
+++ b/src/__test__/index.test.ts
@@ -267,7 +267,7 @@ describe("tools", () => {
   })
 
   it("linear_comment tool posts a comment", async () => {
-    mockFetch.mockResolvedValue({
+    mockFetch.mockResolvedValueOnce({
       ok: true,
       json: () =>
         Promise.resolve({
@@ -388,6 +388,63 @@ describe("tools", () => {
     expect(result.details).toEqual({ status: "failed" })
   })
 
+  it("linear_comment emits response activity when agentSessionId exists", async () => {
+    const { agentSessionMap } = await import("../../src/webhook-handler.js")
+    agentSessionMap.set("issue-emit-1", "sess-emit-1")
+
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            data: { commentCreate: { success: true, comment: { id: "c-emit" } } },
+          }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: { agentActivityCreate: { success: true } } }),
+      })
+
+    const mod = await import("../../index.js")
+    const api = makeApi()
+    mod.default(api)
+
+    const commentTool = api.registerTool.mock.calls.find((call: any) => call[0].name === "linear_comment")?.[0]
+    const result = await commentTool.execute("tc-emit", { issueId: "issue-emit-1", body: "Activity test" })
+
+    expect(result.content[0].text).toContain("issue-emit-1")
+    expect(mockFetch).toHaveBeenCalledTimes(2) // createComment + emitActivity
+    agentSessionMap.delete("issue-emit-1")
+  })
+
+  it("linear_comment emits error activity when comment fails and agentSessionId exists", async () => {
+    const { agentSessionMap } = await import("../../src/webhook-handler.js")
+    agentSessionMap.set("issue-err-1", "sess-err-1")
+
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        text: () => Promise.resolve("Server Error"),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: { agentActivityCreate: { success: true } } }),
+      })
+
+    const mod = await import("../../index.js")
+    const api = makeApi()
+    mod.default(api)
+
+    const commentTool = api.registerTool.mock.calls.find((call: any) => call[0].name === "linear_comment")?.[0]
+    const result = await commentTool.execute("tc-err", { issueId: "issue-err-1", body: "fail" })
+
+    expect(result.content[0].text).toContain("Failed")
+    expect(result.details).toEqual({ status: "failed" })
+    expect(mockFetch).toHaveBeenCalledTimes(2) // createComment failed + emitActivity error
+    agentSessionMap.delete("issue-err-1")
+  })
+
   it("linear_update_status error path returns failure", async () => {
     mockFetch.mockResolvedValue({
       ok: false,
@@ -474,9 +531,31 @@ describe("tools", () => {
     const hook = api.registerHook.mock.calls[0][1]
     await hook({ sessionKey: "linear:issue-1", success: false })
 
-    // Should not update status or send notification
+    // Should not update status or send notification (no agentSessionId in map)
     expect(mockFetch).not.toHaveBeenCalled()
     expect(mockSendMessageTelegram).not.toHaveBeenCalled()
+  })
+
+  it("onSubagentEnded emits error activity when session fails with agentSessionId", async () => {
+    const { agentSessionMap } = await import("../../src/webhook-handler.js")
+    agentSessionMap.set("issue-fail-1", "sess-fail-1")
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ data: { agentActivityCreate: { success: true } } }),
+    })
+
+    const mod = await import("../../index.js")
+    const api = makeApi()
+    mod.default(api)
+
+    const hook = api.registerHook.mock.calls[0][1]
+    await hook({ sessionKey: "linear:issue-fail-1", success: false })
+
+    expect(mockFetch).toHaveBeenCalledTimes(1) // emitActivity error
+    expect(mockSendMessageTelegram).not.toHaveBeenCalled()
+    // agentSessionMap should be cleaned up in finally
+    expect(agentSessionMap.has("issue-fail-1")).toBe(false)
   })
 
   it("onSubagentEnded skips when no runtime channel", async () => {

--- a/src/__test__/linear-api.test.ts
+++ b/src/__test__/linear-api.test.ts
@@ -78,6 +78,7 @@ describe("LinearAgentApi", () => {
       const { LinearAgentApi } = await import("../api/linear-api.js")
       const api = new LinearAgentApi("lin_api_test")
 
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
       mockFetch.mockResolvedValue({
         ok: true,
         json: () =>
@@ -87,9 +88,11 @@ describe("LinearAgentApi", () => {
           }),
       })
 
-      // Current behavior: returns data when errors AND data are both present
       const result = await api.getTeams()
       expect(result).toHaveLength(1)
+      // Partial errors should be logged as warnings
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("partial errors"))
+      warnSpy.mockRestore()
     })
 
     it("throws on HTTP error", async () => {

--- a/src/__test__/webhook-handler.test.ts
+++ b/src/__test__/webhook-handler.test.ts
@@ -268,6 +268,7 @@ describe("handleWebhook", () => {
 
       // Mock fetch for updateIssueState flow:
       // 1) getIssueDetails  2) getTeamStates  3) issueUpdate mutation
+      // 4) emitActivity (initial thought)
       mockFetch
         .mockResolvedValueOnce({
           ok: true,
@@ -303,6 +304,10 @@ describe("handleWebhook", () => {
           ok: true,
           json: () => Promise.resolve({ data: { issueUpdate: { success: true } } }),
         })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ data: { agentActivityCreate: { success: true } } }),
+        })
 
       const payload = uniqueCreated()
       const { req, res } = makeSignedReq(payload, SECRET)
@@ -310,8 +315,8 @@ describe("handleWebhook", () => {
       await handleWebhook(api, req, res)
 
       expect(res.writeHead).toHaveBeenCalledWith(200, expect.any(Object))
-      // 3 fetch calls for the status update flow
-      expect(mockFetch).toHaveBeenCalledTimes(3)
+      // 3 fetch calls for the status update flow + 1 for emitActivity
+      expect(mockFetch).toHaveBeenCalledTimes(4)
       const updateCall = mockFetch.mock.calls[2]
       const body = JSON.parse(updateCall[1].body)
       expect(body.variables.input.stateId).toBe("s-ip")
@@ -442,9 +447,34 @@ describe("handleWebhook", () => {
   describe("Comment create event", () => {
     // -----------------------------------------------------------------------
 
-    it("handles Comment type webhooks (fallback path)", async () => {
+    it("handles Comment type webhooks (fallback path) — dispatches agent when token available", async () => {
       const { handleWebhook } = await import("../webhook-handler.js")
-      const api = makeApi()
+      const api = makeApi({ accessToken: "lin_test_token" })
+
+      // Mock fetch for: getIssueDetails (for handleCommentCreate)
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            data: {
+              issue: {
+                id: `issue-comment-${uid}`,
+                identifier: "ENG-99",
+                title: "Comment Issue",
+                description: "From comment",
+                url: "https://linear.app/eng/issue/ENG-99",
+                state: { name: "Todo", type: "unstarted" },
+                creator: null,
+                assignee: null,
+                labels: { nodes: [] },
+                team: { id: "team-001", key: "ENG", name: "Engineering" },
+                comments: { nodes: [] },
+                project: null,
+              },
+            },
+          }),
+      })
+
       const payload = {
         type: "Comment",
         action: "create",
@@ -460,8 +490,141 @@ describe("handleWebhook", () => {
       await handleWebhook(api, req, res)
 
       expect(res.writeHead).toHaveBeenCalledWith(200, expect.any(Object))
-      // Comment path does not dispatch agent
+      // Comment fallback path should dispatch agent
+      expect(mockSubagentRun).toHaveBeenCalled()
+    })
+
+    it("comment fallback skips when no token available", async () => {
+      const { handleWebhook } = await import("../webhook-handler.js")
+      const api = makeApi()
+      // No accessToken configured
+      const payload = {
+        type: "Comment",
+        action: "create",
+        createdAt: `2026-04-01T13:00:${String(uid++).padStart(2, "0")}.000Z`,
+        data: {
+          id: `comment-notoken-${uid}`,
+          body: "@Linus help please",
+          issue: { id: `issue-notoken-${uid}` },
+        },
+      }
+      const { req, res } = makeSignedReq(payload, SECRET)
+
+      await handleWebhook(api, req, res)
+
+      expect(res.writeHead).toHaveBeenCalledWith(200, expect.any(Object))
       expect(mockSubagentRun).not.toHaveBeenCalled()
+    })
+
+    it("comment fallback handles getIssueDetails failure gracefully", async () => {
+      const { handleWebhook } = await import("../webhook-handler.js")
+      const api = makeApi({ accessToken: "lin_test_token" })
+
+      mockFetch.mockRejectedValueOnce(new Error("fetch failed"))
+
+      const payload = {
+        type: "Comment",
+        action: "create",
+        createdAt: `2026-04-01T13:00:${String(uid++).padStart(2, "0")}.000Z`,
+        data: {
+          id: `comment-fetch-fail-${uid}`,
+          body: "@Linus help",
+          issue: { id: `issue-fetch-fail-${uid}` },
+        },
+      }
+      const { req, res } = makeSignedReq(payload, SECRET)
+
+      await handleWebhook(api, req, res)
+
+      expect(res.writeHead).toHaveBeenCalledWith(200, expect.any(Object))
+      expect(mockSubagentRun).not.toHaveBeenCalled()
+    })
+
+    it("comment fallback updates status to In Progress", async () => {
+      const { handleWebhook } = await import("../webhook-handler.js")
+      const api = makeApi({ accessToken: "lin_test_token" })
+
+      const commentIssueId = `issue-cf-status-${uid}`
+      // handleCommentCreate calls getIssueDetails, then updateIssueState calls:
+      //   getIssueDetails again + getTeamStates + issueUpdate
+      mockFetch
+        // 1) getIssueDetails (handleCommentCreate)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              data: {
+                issue: {
+                  id: commentIssueId,
+                  identifier: "ENG-88",
+                  title: "Comment Status",
+                  description: "Test",
+                  url: "https://linear.app/eng/issue/ENG-88",
+                  state: { name: "Todo", type: "unstarted" },
+                  creator: null,
+                  assignee: null,
+                  labels: { nodes: [] },
+                  team: { id: "team-001", key: "ENG", name: "Engineering" },
+                  comments: { nodes: [] },
+                  project: null,
+                },
+              },
+            }),
+        })
+        // 2) getIssueDetails (updateIssueState internal)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              data: {
+                issue: {
+                  id: commentIssueId,
+                  team: { id: "team-001", key: "ENG", name: "Engineering" },
+                },
+              },
+            }),
+        })
+        // 3) getTeamStates
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              data: {
+                team: {
+                  states: {
+                    nodes: [
+                      { id: "s-todo", name: "Todo" },
+                      { id: "s-ip", name: "In Progress" },
+                    ],
+                  },
+                },
+              },
+            }),
+        })
+        // 4) issueUpdate
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ data: { issueUpdate: { success: true } } }),
+        })
+
+      const payload = {
+        type: "Comment",
+        action: "create",
+        createdAt: `2026-04-01T13:00:${String(uid++).padStart(2, "0")}.000Z`,
+        data: {
+          id: `comment-cf-status-${uid}`,
+          body: "@Linus update status",
+          issue: { id: commentIssueId },
+        },
+      }
+      const { req, res } = makeSignedReq(payload, SECRET)
+
+      await handleWebhook(api, req, res)
+
+      expect(res.writeHead).toHaveBeenCalledWith(200, expect.any(Object))
+      expect(mockSubagentRun).toHaveBeenCalled()
+      // 4 fetch calls: getIssueDetails (handleCommentCreate) + getIssueDetails + getTeamStates + issueUpdate (updateIssueState)
+      expect(mockFetch).toHaveBeenCalledTimes(4)
     })
 
     it("skips Comment without mention trigger", async () => {

--- a/src/api/linear-api.ts
+++ b/src/api/linear-api.ts
@@ -202,8 +202,11 @@ export class LinearAgentApi {
       }
 
       const payload = await retry.json()
-      if (payload.errors?.length && !payload.data) {
-        throw new Error(`Linear GraphQL: ${JSON.stringify(payload.errors)}`)
+      if (payload.errors?.length) {
+        console.warn(`Linear GraphQL partial errors: ${JSON.stringify(payload.errors)}`)
+        if (!payload.data) {
+          throw new Error(`Linear GraphQL: ${JSON.stringify(payload.errors)}`)
+        }
       }
 
       return payload.data as T
@@ -215,8 +218,11 @@ export class LinearAgentApi {
     }
 
     const payload = await res.json()
-    if (payload.errors?.length && !payload.data) {
-      throw new Error(`Linear GraphQL: ${JSON.stringify(payload.errors)}`)
+    if (payload.errors?.length) {
+      console.warn(`Linear GraphQL partial errors: ${JSON.stringify(payload.errors)}`)
+      if (!payload.data) {
+        throw new Error(`Linear GraphQL: ${JSON.stringify(payload.errors)}`)
+      }
     }
 
     return payload.data as T

--- a/src/webhook-handler.ts
+++ b/src/webhook-handler.ts
@@ -16,6 +16,9 @@ import { sanitizePromptInput } from "./utils.js"
 
 // Dedup tracking
 const recentlyProcessed = new Map<string, number>()
+
+// Maps issueId → Linear agent session ID, so tools can emit activity updates
+export const agentSessionMap = new Map<string, string>()
 const DEDUP_TTL_MS = 60_000
 let lastSweep = Date.now()
 
@@ -23,8 +26,8 @@ let lastSweep = Date.now()
 // parallel agent sessions (e.g. "created" followed quickly by "prompted").
 const activeRuns = new Set<string>()
 
-export function clearActiveRun(sessionKey: string): void {
-  if (sessionKey.startsWith("linear:")) {
+export function clearActiveRun(sessionKey: string, prefix = "linear:"): void {
+  if (sessionKey.startsWith(prefix)) {
     activeRuns.delete(sessionKey)
   }
 }
@@ -251,34 +254,42 @@ async function handleSessionCreated(
   const isMentionTriggered = commentBody && !commentBody.includes(AGENT_SESSION_MARKER)
   const prompt = isMentionTriggered ? commentBody : issue.description || issue.title
 
+  // Store agent session ID for activity emission
+  const agentSessionId = session.id as string | undefined
+  if (agentSessionId) {
+    agentSessionMap.set(issueId, agentSessionId)
+  }
+
   api.logger.info(`Linear Light: session created for ${issue.identifier} (${isMentionTriggered ? "mention" : "auto"})`)
 
+  // Resolve Linear API for status update and activity emission
+  const tokenInfo = resolveLinearToken(config)
+
   // Update issue status to In Progress
-  if (config?.autoInProgress !== false) {
+  if (config?.autoInProgress !== false && tokenInfo.accessToken) {
     try {
-      const tokenInfo = resolveLinearToken(config)
-      if (tokenInfo.accessToken) {
-        const linearApi = new LinearAgentApi(tokenInfo.accessToken, {
-          refreshToken: tokenInfo.refreshToken,
-          expiresAt: tokenInfo.expiresAt,
-          clientId: (config?.linearClientId as string) || process.env.LINEAR_CLIENT_ID,
-          clientSecret: (config?.linearClientSecret as string) || process.env.LINEAR_CLIENT_SECRET,
-          source: tokenInfo.source,
-        })
-        await linearApi.updateIssueState(issueId, "In Progress")
-        api.logger.info(`Linear Light: ${issue.identifier} → In Progress`)
-      }
+      const linearApi = new LinearAgentApi(tokenInfo.accessToken, {
+        refreshToken: tokenInfo.refreshToken,
+        expiresAt: tokenInfo.expiresAt,
+        clientId: (config?.linearClientId as string) || process.env.LINEAR_CLIENT_ID,
+        clientSecret: (config?.linearClientSecret as string) || process.env.LINEAR_CLIENT_SECRET,
+        source: tokenInfo.source,
+      })
+      await linearApi.updateIssueState(issueId, "In Progress")
+      api.logger.info(`Linear Light: ${issue.identifier} → In Progress`)
     } catch (err) {
       api.logger.warn(`Linear Light: failed to update status: ${err}`)
     }
   }
 
   // Build the message for the agent
+  const safeTitle = sanitizePromptInput(issue.title, 200)
+  const safeDescription = issue.description ? sanitizePromptInput(issue.description) : ""
   const sanitizedPrompt = sanitizePromptInput(prompt)
 
   const message = [
-    `[Linear Issue ${issue.identifier}] ${issue.title}`,
-    issue.description ? `\n---\n${issue.description}` : "",
+    `[Linear Issue ${issue.identifier}] ${safeTitle}`,
+    safeDescription ? `\n---\n${safeDescription}` : "",
     isMentionTriggered ? `\n---\n**User comment:**\n${sanitizedPrompt}` : "",
     `\n---\nIssue URL: ${issue.url}`,
     `\nUse linear_comment() to reply on the issue, linear_update_status() to change status.`,
@@ -290,6 +301,25 @@ async function handleSessionCreated(
     message,
     sessionKey,
   })
+
+  // Emit initial activity so Linear shows the session as active
+  if (agentSessionId && tokenInfo.accessToken) {
+    try {
+      const linearApi = new LinearAgentApi(tokenInfo.accessToken, {
+        refreshToken: tokenInfo.refreshToken,
+        expiresAt: tokenInfo.expiresAt,
+        clientId: (config?.linearClientId as string) || process.env.LINEAR_CLIENT_ID,
+        clientSecret: (config?.linearClientSecret as string) || process.env.LINEAR_CLIENT_SECRET,
+        source: tokenInfo.source,
+      })
+      await linearApi.emitActivity(agentSessionId, {
+        type: "thought",
+        body: `Starting work on ${issue.identifier}: ${issue.title}`,
+      })
+    } catch (err) {
+      api.logger.warn(`Linear Light: failed to emit initial activity: ${err}`)
+    }
+  }
 
   api.logger.info(`Linear Light: dispatched agent for ${issue.identifier}`)
 }
@@ -318,6 +348,13 @@ async function handleSessionPrompted(
   const issueId = session.issue.id
   const sessionPrefix = (config?.sessionPrefix as string) || "linear:"
   const sessionKey = `${sessionPrefix}${issueId}`
+
+  // Ensure agent session ID is available for activity emission
+  const agentSessionId = session.id as string | undefined
+  if (agentSessionId) {
+    agentSessionMap.set(issueId, agentSessionId)
+  }
+
   const prompt = sanitizePromptInput(activity.content.body)
 
   const message = [`[Linear ${session.issue.identifier} follow-up]`, prompt].join("\n")
@@ -331,8 +368,10 @@ async function handleSessionPrompted(
 }
 
 /**
- * Handle comment create events (fallback for non-agent-session setups)
- * If the comment contains the trigger text, treat it as a request
+ * Handle comment create events (fallback for non-agent-session setups).
+ * If the comment contains the trigger text, treat it as a request.
+ * This path is used when Linear Agent Sessions are not available —
+ * the webhook receives Comment events directly instead of AgentSessionEvent.
  */
 async function handleCommentCreate(
   api: OpenClawPluginApi,
@@ -349,9 +388,64 @@ async function handleCommentCreate(
     return
   }
 
-  // Already handled by AgentSessionEvent if agent sessions are enabled
-  // This is a fallback path
-  api.logger.debug?.(
-    `Linear Light: comment trigger detected (fallback path), skipping — AgentSessionEvent should handle this`,
-  )
+  const issueId = comment.issue.id
+  const sessionPrefix = (config?.sessionPrefix as string) || "linear:"
+  const sessionKey = `${sessionPrefix}${issueId}`
+
+  api.logger.info(`Linear Light: comment trigger detected (fallback path) for issue ${issueId}`)
+
+  // Resolve Linear API to fetch full issue details and update status
+  const tokenInfo = resolveLinearToken(config)
+  if (!tokenInfo.accessToken) {
+    api.logger.warn("Linear Light: comment fallback triggered but no Linear API token available")
+    return
+  }
+
+  const linearApi = new LinearAgentApi(tokenInfo.accessToken, {
+    refreshToken: tokenInfo.refreshToken,
+    expiresAt: tokenInfo.expiresAt,
+    clientId: (config?.linearClientId as string) || process.env.LINEAR_CLIENT_ID,
+    clientSecret: (config?.linearClientSecret as string) || process.env.LINEAR_CLIENT_SECRET,
+    source: tokenInfo.source,
+  })
+
+  let issue: Awaited<ReturnType<LinearAgentApi["getIssueDetails"]>>
+  try {
+    issue = await linearApi.getIssueDetails(issueId)
+  } catch (err) {
+    api.logger.error(`Linear Light: failed to fetch issue ${issueId}: ${err}`)
+    return
+  }
+
+  // Update issue status to In Progress
+  if (config?.autoInProgress !== false) {
+    try {
+      await linearApi.updateIssueState(issueId, "In Progress")
+      api.logger.info(`Linear Light: ${issue.identifier} → In Progress`)
+    } catch (err) {
+      api.logger.warn(`Linear Light: failed to update status: ${err}`)
+    }
+  }
+
+  // Build the message for the agent
+  const sanitizedPrompt = sanitizePromptInput(comment.body)
+  const safeTitle = sanitizePromptInput(issue.title, 200)
+  const safeDescription = issue.description ? sanitizePromptInput(issue.description) : ""
+
+  const message = [
+    `[Linear Issue ${issue.identifier}] ${safeTitle}`,
+    safeDescription ? `\n---\n${safeDescription}` : "",
+    `\n---\n**User comment:**\n${sanitizedPrompt}`,
+    `\n---\nIssue URL: ${issue.url}`,
+    `\nUse linear_comment() to reply on the issue, linear_update_status() to change status.`,
+    `\nWhen done, update status to "Done" and I'll notify the user for review.`,
+  ].join("\n")
+
+  // Dispatch to OpenClaw agent with session key for continuity
+  await api.runtime.subagent.run({
+    message,
+    sessionKey,
+  })
+
+  api.logger.info(`Linear Light: dispatched agent for ${issue.identifier} (comment fallback)`)
 }


### PR DESCRIPTION
- PR #34: sanitize issue.title and issue.description in agent prompt
- PR #30: wire up emitActivity for Linear agent session progress
- PR #27: log GraphQL partial errors instead of silently discarding
- PR #26: implement handleCommentCreate fallback for comment-triggered sessions
- Fix clearActiveRun hardcoded "linear:" prefix breaking custom sessionPrefix
- Remove unused fixtures (makeCommentCreate, makeMockApi, makeMockReqRes)