### PR TITLE
fix: sanitize HTTP error responses to prevent information disclosure

### DIFF
--- a/src/__test__/linear-api.test.ts
+++ b/src/__test__/linear-api.test.ts
@@ -127,17 +127,21 @@ describe("LinearAgentApi", () => {
       warnSpy.mockRestore()
     })
 
-    it("throws on HTTP error", async () => {
+    it("throws on HTTP error with sanitized message", async () => {
       const { LinearAgentApi } = await import("../api/linear-api.js")
       const api = new LinearAgentApi("lin_api_test")
 
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
       mockFetch.mockResolvedValue({
         ok: false,
         status: 500,
-        text: () => Promise.resolve("Internal Server Error"),
+        text: () => Promise.resolve("Internal Server Error with secret info"),
       })
 
-      await expect(api.getTeams()).rejects.toThrow("Linear API 500")
+      await expect(api.getTeams()).rejects.toThrow("Linear API request failed (500)")
+      // Full response body must be logged server-side, not exposed in thrown message
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("secret info"))
+      errorSpy.mockRestore()
     })
   })
 

--- a/src/api/linear-api.ts
+++ b/src/api/linear-api.ts
@@ -200,7 +200,8 @@ export class LinearAgentApi {
 
       if (!retry.ok) {
         const text = await retry.text()
-        throw new Error(`Linear API ${retry.status}: ${text}`)
+        console.error(`Linear API ${retry.status}: ${text}`)
+        throw new Error(`Linear API request failed (${retry.status})`)
       }
 
       const payload = await retry.json()
@@ -217,7 +218,8 @@ export class LinearAgentApi {
 
     if (!res.ok) {
       const text = await res.text()
-      throw new Error(`Linear API ${res.status}: ${text}`)
+      console.error(`Linear API ${res.status}: ${text}`)
+      throw new Error(`Linear API request failed (${res.status})`)
     }
 
     const payload = await res.json()


### PR DESCRIPTION
Assignee: @QiuYi111 ([qiuyi200311](https://linear.app/jingyi-dev/profiles/qiuyi200311))

## Summary

- Sanitize HTTP error responses from Linear API — full response bodies are now logged server-side via `console.error` instead of being included in thrown `Error` messages
- Extends the existing GraphQL error sanitization (from prior commit) to cover HTTP-level error paths as well

## Problem

`src/api/linear-api.ts` was throwing HTTP error responses with full response body text:

```ts
throw new Error(`Linear API ${res.status}: ${text}`)
```

This could leak internal API details, schema structure, or workspace information to agent message context.

## Changes

- **`src/api/linear-api.ts`**: HTTP error paths (lines 201–204, 219–222) now log full response body server-side and throw sanitized messages (`Linear API request failed (status)`)
- **`src/__test__/linear-api.test.ts`**: Updated HTTP error test to verify sanitized thrown message and server-side logging

## Testing

- `npm run lint` — 0 errors
- `npm run typecheck` — passes
- `npm run test:coverage` — 75/75 tests pass, 90.54% line coverage

Closes #59. Related: [DEV-106](https://linear.app/jingyi-dev/issue/DEV-106)

---

> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a "changes requested" review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->