### PR TITLE
feat: add OAuth authorization flow for bot identity

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -14,6 +14,7 @@
 
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk"
 import { LinearAgentApi, resolveLinearToken } from "./src/api/linear-api.js"
+import { handleOAuthCallback, handleOAuthInit } from "./src/oauth-handler.js"
 import { agentSessionMap, clearActiveRun, handleWebhook } from "./src/webhook-handler.js"
 
 export default function register(api: OpenClawPluginApi) {
@@ -25,8 +26,28 @@ export default function register(api: OpenClawPluginApi) {
   }
 
   const tokenInfo = resolveLinearToken(config)
+
+  // Always register OAuth routes (needed to obtain the first token)
+  api.registerHttpRoute({
+    path: "/linear-light/oauth/callback",
+    auth: "plugin",
+    match: "exact",
+    handler: async (req, res) => {
+      await handleOAuthCallback(api, req, res)
+    },
+  })
+
+  api.registerHttpRoute({
+    path: "/linear-light/oauth/init",
+    auth: "plugin",
+    match: "exact",
+    handler: async (req, res) => {
+      await handleOAuthInit(api, req, res)
+    },
+  })
+
   if (!tokenInfo.accessToken) {
-    api.logger.warn("Linear Light: no access token. Set LINEAR_ACCESS_TOKEN env var or run OAuth flow.")
+    api.logger.warn("Linear Light: no access token. Visit /linear-light/oauth/init to start OAuth flow.")
     return
   }
 

--- a/src/__test__/index.test.ts
+++ b/src/__test__/index.test.ts
@@ -20,6 +20,13 @@ vi.mock("node:fs", () => ({
     throw new Error("no file")
   }),
   writeFileSync: vi.fn(),
+  renameSync: vi.fn(),
+}))
+
+// Mock oauth-store — return null by default (no stored token)
+vi.mock("../../src/api/oauth-store.js", () => ({
+  readStoredToken: vi.fn(() => null),
+  writeStoredToken: vi.fn(),
 }))
 
 // Mock crypto for webhook signature
@@ -135,7 +142,7 @@ describe("plugin register()", () => {
     expect(api.registerTool).not.toHaveBeenCalled()
   })
 
-  it("warns and skips when no access token", async () => {
+  it("warns and skips webhook/tools when no access token, but registers OAuth routes", async () => {
     const mod = await import("../../index.js")
     const api = makeApi({ enabled: true, accessToken: undefined })
     delete process.env.LINEAR_ACCESS_TOKEN
@@ -143,14 +150,27 @@ describe("plugin register()", () => {
 
     mod.default(api)
     expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining("no access token"))
+
+    // OAuth routes should still be registered
+    const paths = api.registerHttpRoute.mock.calls.map((call: any) => call[0].path)
+    expect(paths).toContain("/linear-light/oauth/callback")
+    expect(paths).toContain("/linear-light/oauth/init")
+
+    // Webhook and tools should NOT be registered
+    expect(paths).not.toContain("/linear-light/webhook")
+    expect(api.registerTool).not.toHaveBeenCalled()
   })
 
-  it("registers webhook route, tools, and lifecycle hook", async () => {
+  it("registers OAuth routes, webhook route, tools, and lifecycle hook", async () => {
     const mod = await import("../../index.js")
     const api = makeApi()
 
     mod.default(api)
-    expect(api.registerHttpRoute).toHaveBeenCalledWith(expect.objectContaining({ path: "/linear-light/webhook" }))
+
+    const paths = api.registerHttpRoute.mock.calls.map((call: any) => call[0].path)
+    expect(paths).toContain("/linear-light/oauth/callback")
+    expect(paths).toContain("/linear-light/oauth/init")
+    expect(paths).toContain("/linear-light/webhook")
     expect(api.registerTool).toHaveBeenCalled()
     expect(api.registerHook).toHaveBeenCalledWith("subagent_ended", expect.any(Function))
   })

--- a/src/__test__/linear-api.test.ts
+++ b/src/__test__/linear-api.test.ts
@@ -8,7 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 const mockFetch = vi.fn()
 vi.stubGlobal("fetch", mockFetch)
 
-// Mock fs for resolveLinearToken
+// Mock fs for resolveLinearToken and persistToCyrusConfig
 const mockReadFileSync = vi.fn()
 const mockWriteFileSync = vi.fn()
 const mockRenameSync = vi.fn()
@@ -16,6 +16,12 @@ vi.mock("node:fs", () => ({
   readFileSync: mockReadFileSync,
   writeFileSync: mockWriteFileSync,
   renameSync: mockRenameSync,
+}))
+
+// Mock oauth-store — return null by default (no stored token)
+vi.mock("../api/oauth-store.js", () => ({
+  readStoredToken: vi.fn(() => null),
+  writeStoredToken: vi.fn(),
 }))
 
 describe("LinearAgentApi", () => {
@@ -214,6 +220,49 @@ describe("LinearAgentApi", () => {
       // Only API call, no refresh
       expect(mockFetch).toHaveBeenCalledTimes(1)
     })
+
+    it("coalesces concurrent refresh requests", async () => {
+      const { LinearAgentApi } = await import("../api/linear-api.js")
+
+      // Create two API instances with the same clientId (same refresh key)
+      const api1 = new LinearAgentApi("lin_oauth_test", {
+        refreshToken: "refresh-123",
+        clientId: "same-client",
+        clientSecret: "csec",
+        expiresAt: Date.now() - 1000,
+      })
+      const api2 = new LinearAgentApi("lin_oauth_test", {
+        refreshToken: "refresh-123",
+        clientId: "same-client",
+        clientSecret: "csec",
+        expiresAt: Date.now() - 1000,
+      })
+
+      // Refresh call — only one should hit the token endpoint
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            access_token: "new_token",
+            refresh_token: "new_refresh",
+            expires_in: 3600,
+          }),
+      })
+
+      // Two API calls that both need refresh
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ data: { teams: { nodes: [] } } }),
+      })
+
+      // Run both concurrently — only one refresh should happen
+      const [, _result2] = await Promise.all([api1.getTeams(), api2.getTeams()])
+
+      // Should have 1 refresh + 2 API calls = 3 fetch calls total
+      expect(mockFetch).toHaveBeenCalledTimes(3)
+      // First call should be the refresh
+      expect(mockFetch.mock.calls[0][0]).toBe("https://api.linear.app/oauth/token")
+    })
   })
 
   describe("401 retry", () => {
@@ -276,9 +325,10 @@ describe("LinearAgentApi", () => {
     })
   })
 
-  describe("persistToken (cyrus source)", () => {
-    it("writes refreshed token back to cyrus config", async () => {
+  describe("persistToken (store + cyrus source)", () => {
+    it("writes refreshed token to plugin-local store and cyrus config", async () => {
       const { LinearAgentApi } = await import("../api/linear-api.js")
+      const { writeStoredToken } = await import("../api/oauth-store.js")
 
       mockReadFileSync.mockReturnValue(
         JSON.stringify({
@@ -318,7 +368,15 @@ describe("LinearAgentApi", () => {
 
       await api.getTeams()
 
-      // writeFileSync should write to a temp file, then renameSync for atomicity
+      // Should write to plugin-local store
+      expect(writeStoredToken).toHaveBeenCalledWith(
+        expect.objectContaining({
+          accessToken: "new-access-token",
+          refreshToken: "new-refresh-token",
+        }),
+      )
+
+      // Should also write to Cyrus config
       expect(mockWriteFileSync).toHaveBeenCalled()
       const writtenPath = mockWriteFileSync.mock.calls[0][0]
       expect(writtenPath).toMatch(/\.tmp$/)
@@ -326,7 +384,6 @@ describe("LinearAgentApi", () => {
       const ws = written.linearWorkspaces.default
       expect(ws.linearToken).toBe("new-access-token")
       expect(ws.linearRefreshToken).toBe("new-refresh-token")
-      // rename from temp → final path for atomic persistence
       expect(mockRenameSync).toHaveBeenCalledWith(writtenPath, expect.stringMatching(/config\.json$/))
     })
   })
@@ -369,7 +426,27 @@ describe("LinearAgentApi", () => {
       expect(result).toEqual({ accessToken: "cfg-token-123", source: "config" })
     })
 
-    it("returns token from Cyrus config", async () => {
+    it("returns token from plugin-local store", async () => {
+      const { readStoredToken } = await import("../api/oauth-store.js")
+      vi.mocked(readStoredToken).mockReturnValue({
+        accessToken: "stored-token",
+        refreshToken: "stored-refresh",
+        expiresAt: 1234567890,
+      })
+
+      const { resolveLinearToken } = await import("../api/linear-api.js")
+      const result = resolveLinearToken()
+      expect(result.accessToken).toBe("stored-token")
+      expect(result.source).toBe("store")
+      expect(result.refreshToken).toBe("stored-refresh")
+
+      vi.mocked(readStoredToken).mockReturnValue(null)
+    })
+
+    it("returns token from Cyrus config when store is empty", async () => {
+      const { readStoredToken } = await import("../api/oauth-store.js")
+      vi.mocked(readStoredToken).mockReturnValue(null)
+
       const { resolveLinearToken } = await import("../api/linear-api.js")
       mockReadFileSync.mockReturnValue(
         JSON.stringify({
@@ -390,6 +467,9 @@ describe("LinearAgentApi", () => {
     })
 
     it("returns token from env var as fallback", async () => {
+      const { readStoredToken } = await import("../api/oauth-store.js")
+      vi.mocked(readStoredToken).mockReturnValue(null)
+
       const { resolveLinearToken } = await import("../api/linear-api.js")
       mockReadFileSync.mockImplementation(() => {
         throw new Error("no file")
@@ -401,6 +481,9 @@ describe("LinearAgentApi", () => {
     })
 
     it("returns none when no token available", async () => {
+      const { readStoredToken } = await import("../api/oauth-store.js")
+      vi.mocked(readStoredToken).mockReturnValue(null)
+
       const { resolveLinearToken } = await import("../api/linear-api.js")
       mockReadFileSync.mockImplementation(() => {
         throw new Error("no file")

--- a/src/__test__/oauth-handler.test.ts
+++ b/src/__test__/oauth-handler.test.ts
@@ -1,0 +1,267 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+// ---------------------------------------------------------------------------
+// OAuth handler unit tests
+// ---------------------------------------------------------------------------
+
+const mockFetch = vi.fn()
+vi.stubGlobal("fetch", mockFetch)
+
+// Mock crypto for PKCE
+vi.mock("node:crypto", () => ({
+  randomBytes: vi.fn((size: number) => ({
+    toString: vi.fn(() => "a".repeat(size * 2)), // deterministic base64url-like string
+  })),
+  createHash: vi.fn(() => ({
+    update: vi.fn(() => ({
+      digest: vi.fn(() => "mock-challenge"),
+    })),
+  })),
+}))
+
+// Mock oauth-store
+const mockWriteStoredToken = vi.fn()
+vi.mock("../api/oauth-store.js", () => ({
+  writeStoredToken: mockWriteStoredToken,
+}))
+
+function makeApi(configOverrides: Record<string, unknown> = {}) {
+  return {
+    pluginConfig: {
+      enabled: true,
+      linearClientId: "test-client-id",
+      linearClientSecret: "test-client-secret",
+      ...configOverrides,
+    },
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    },
+  } as any
+}
+
+function makeReq(url: string, headers: Record<string, string> = {}) {
+  return {
+    url,
+    headers: {
+      host: "localhost:3000",
+      "x-forwarded-proto": "https",
+      ...headers,
+    },
+  }
+}
+
+function makeRes() {
+  const res: any = {
+    statusCode: 0,
+    headers: {},
+    body: "",
+    writeHead: vi.fn((status: number, hdrs: Record<string, string>) => {
+      res.statusCode = status
+      res.headers = hdrs
+    }),
+    end: vi.fn((body?: string) => {
+      res.body = body || ""
+    }),
+  }
+  return res
+}
+
+describe("generateAuthorizationURL", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("generates a valid authorization URL with PKCE and actor=app", async () => {
+    const { generateAuthorizationURL } = await import("../oauth-handler.js")
+    const { url, state, codeVerifier } = generateAuthorizationURL("my-client", "https://example.com/callback")
+
+    expect(url).toContain("https://linear.app/oauth/authorize")
+    expect(url).toContain("client_id=my-client")
+    expect(url).toContain("redirect_uri=")
+    expect(url).toContain("response_type=code")
+    expect(url).toContain("scope=read%2Cwrite")
+    expect(url).toContain("state=")
+    expect(url).toContain("code_challenge=mock-challenge")
+    expect(url).toContain("code_challenge_method=S256")
+    expect(url).toContain("actor=app")
+    expect(state).toBeTruthy()
+    expect(codeVerifier).toBeTruthy()
+  })
+
+  it("uses custom state and scopes when provided", async () => {
+    const { generateAuthorizationURL } = await import("../oauth-handler.js")
+    const { url, state } = generateAuthorizationURL("my-client", "https://example.com/callback", {
+      state: "custom-state",
+      scopes: "read",
+    })
+
+    expect(url).toContain("state=custom-state")
+    expect(url).toContain("scope=read")
+    expect(state).toBe("custom-state")
+  })
+})
+
+describe("handleOAuthInit", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("redirects to Linear authorize URL", async () => {
+    const { handleOAuthInit } = await import("../oauth-handler.js")
+    const api = makeApi()
+    const req = makeReq("/linear-light/oauth/init")
+    const res = makeRes()
+
+    await handleOAuthInit(api, req, res)
+
+    expect(res.statusCode).toBe(302)
+    expect(res.headers.Location).toContain("https://linear.app/oauth/authorize")
+  })
+
+  it("returns 400 when clientId is not configured", async () => {
+    const { handleOAuthInit } = await import("../oauth-handler.js")
+    const api = makeApi({ linearClientId: undefined })
+    delete process.env.LINEAR_CLIENT_ID
+    const req = makeReq("/linear-light/oauth/init")
+    const res = makeRes()
+
+    await handleOAuthInit(api, req, res)
+
+    expect(res.statusCode).toBe(400)
+    expect(res.body).toContain("linearClientId not configured")
+  })
+})
+
+describe("handleOAuthCallback", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("exchanges code for tokens and stores them", async () => {
+    const { handleOAuthCallback, generateAuthorizationURL } = await import("../oauth-handler.js")
+
+    // First, generate a URL to create a pending state
+    generateAuthorizationURL("test-client-id", "https://localhost:3000/linear-light/oauth/callback")
+
+    // Mock the token exchange
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          access_token: "new-access",
+          refresh_token: "new-refresh",
+          expires_in: 3600,
+        }),
+    })
+
+    const api = makeApi()
+    const req = makeReq("/linear-light/oauth/callback?code=test-code&state=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") // matches randomBytes(16).toString("hex") mock
+    const res = makeRes()
+
+    await handleOAuthCallback(api, req, res)
+
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toContain("OAuth Setup Complete")
+    expect(mockWriteStoredToken).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accessToken: "new-access",
+        refreshToken: "new-refresh",
+      }),
+    )
+  })
+
+  it("returns 400 when OAuth error parameter is present", async () => {
+    const { handleOAuthCallback } = await import("../oauth-handler.js")
+    const api = makeApi()
+    const req = makeReq("/linear-light/oauth/callback?error=access_denied&state=test")
+    const res = makeRes()
+
+    await handleOAuthCallback(api, req, res)
+
+    expect(res.statusCode).toBe(400)
+    expect(res.body).toContain("access_denied")
+  })
+
+  it("returns 400 when code or state is missing", async () => {
+    const { handleOAuthCallback } = await import("../oauth-handler.js")
+    const api = makeApi()
+    const req = makeReq("/linear-light/oauth/callback?code=only-code")
+    const res = makeRes()
+
+    await handleOAuthCallback(api, req, res)
+
+    expect(res.statusCode).toBe(400)
+    expect(res.body).toContain("Missing code or state")
+  })
+
+  it("returns 400 for invalid or expired state", async () => {
+    const { handleOAuthCallback } = await import("../oauth-handler.js")
+    const api = makeApi()
+    const req = makeReq("/linear-light/oauth/callback?code=test-code&state=invalid-state")
+    const res = makeRes()
+
+    await handleOAuthCallback(api, req, res)
+
+    expect(res.statusCode).toBe(400)
+    expect(res.body).toContain("Invalid or expired state")
+  })
+
+  it("returns 500 when clientId/clientSecret not configured", async () => {
+    const { handleOAuthCallback, generateAuthorizationURL } = await import("../oauth-handler.js")
+
+    generateAuthorizationURL("test-client-id", "https://localhost:3000/linear-light/oauth/callback")
+
+    const api = makeApi({ linearClientId: undefined, linearClientSecret: undefined })
+    delete process.env.LINEAR_CLIENT_ID
+    delete process.env.LINEAR_CLIENT_SECRET
+
+    const req = makeReq("/linear-light/oauth/callback?code=test-code&state=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+    const res = makeRes()
+
+    await handleOAuthCallback(api, req, res)
+
+    expect(res.statusCode).toBe(500)
+    expect(res.body).toContain("Configuration Error")
+  })
+
+  it("returns 502 when token exchange fails", async () => {
+    const { handleOAuthCallback, generateAuthorizationURL } = await import("../oauth-handler.js")
+
+    generateAuthorizationURL("test-client-id", "https://localhost:3000/linear-light/oauth/callback")
+
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      text: () => Promise.resolve("invalid_grant"),
+    })
+
+    const api = makeApi()
+    const req = makeReq("/linear-light/oauth/callback?code=bad-code&state=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+    const res = makeRes()
+
+    await handleOAuthCallback(api, req, res)
+
+    expect(res.statusCode).toBe(502)
+    expect(res.body).toContain("Token Exchange Failed")
+  })
+
+  it("returns 500 on fetch exception", async () => {
+    const { handleOAuthCallback, generateAuthorizationURL } = await import("../oauth-handler.js")
+
+    generateAuthorizationURL("test-client-id", "https://localhost:3000/linear-light/oauth/callback")
+
+    mockFetch.mockRejectedValueOnce(new Error("network error"))
+
+    const api = makeApi()
+    const req = makeReq("/linear-light/oauth/callback?code=test-code&state=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+    const res = makeRes()
+
+    await handleOAuthCallback(api, req, res)
+
+    expect(res.statusCode).toBe(500)
+    expect(res.body).toContain("Internal Error")
+  })
+})

--- a/src/__test__/oauth-store.test.ts
+++ b/src/__test__/oauth-store.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+// ---------------------------------------------------------------------------
+// OAuth store unit tests
+// ---------------------------------------------------------------------------
+
+const mockExistsSync = vi.fn()
+const mockMkdirSync = vi.fn()
+const mockReadFileSync = vi.fn()
+const mockWriteFileSync = vi.fn()
+const mockRenameSync = vi.fn()
+
+vi.mock("node:fs", () => ({
+  existsSync: mockExistsSync,
+  mkdirSync: mockMkdirSync,
+  readFileSync: mockReadFileSync,
+  writeFileSync: mockWriteFileSync,
+  renameSync: mockRenameSync,
+}))
+
+describe("oauth-store", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe("readStoredToken", () => {
+    it("returns null when file does not exist", async () => {
+      mockExistsSync.mockReturnValue(false)
+      const { readStoredToken } = await import("../api/oauth-store.js")
+      expect(readStoredToken()).toBeNull()
+    })
+
+    it("returns null when file has no accessToken", async () => {
+      mockExistsSync.mockReturnValue(true)
+      mockReadFileSync.mockReturnValue(JSON.stringify({ refreshToken: "only-refresh" }))
+      const { readStoredToken } = await import("../api/oauth-store.js")
+      expect(readStoredToken()).toBeNull()
+    })
+
+    it("returns null when file is invalid JSON", async () => {
+      mockExistsSync.mockReturnValue(true)
+      mockReadFileSync.mockReturnValue("not json")
+      const { readStoredToken } = await import("../api/oauth-store.js")
+      expect(readStoredToken()).toBeNull()
+    })
+
+    it("returns stored token with all fields", async () => {
+      mockExistsSync.mockReturnValue(true)
+      const tokenData = {
+        accessToken: "at-123",
+        refreshToken: "rt-456",
+        expiresAt: 1234567890,
+      }
+      mockReadFileSync.mockReturnValue(JSON.stringify(tokenData))
+      const { readStoredToken } = await import("../api/oauth-store.js")
+      const result = readStoredToken()
+      expect(result).toEqual(tokenData)
+    })
+  })
+
+  describe("writeStoredToken", () => {
+    it("creates directory if it does not exist", async () => {
+      mockExistsSync.mockReturnValue(false)
+      const { writeStoredToken } = await import("../api/oauth-store.js")
+
+      writeStoredToken({ accessToken: "at-new" })
+
+      expect(mockMkdirSync).toHaveBeenCalledWith(expect.stringContaining("linear-light"), { recursive: true })
+    })
+
+    it("writes token atomically (tmp + rename)", async () => {
+      mockExistsSync.mockReturnValue(true)
+      const { writeStoredToken } = await import("../api/oauth-store.js")
+
+      writeStoredToken({
+        accessToken: "at-new",
+        refreshToken: "rt-new",
+        expiresAt: 999,
+      })
+
+      expect(mockWriteFileSync).toHaveBeenCalledTimes(1)
+      const [tmpPath, content] = mockWriteFileSync.mock.calls[0]
+      expect(tmpPath).toMatch(/\.tmp$/)
+      expect(JSON.parse(content).accessToken).toBe("at-new")
+      expect(mockRenameSync).toHaveBeenCalledWith(tmpPath, expect.stringContaining("token.json"))
+    })
+
+    it("handles write errors gracefully", async () => {
+      mockExistsSync.mockReturnValue(true)
+      mockWriteFileSync.mockImplementation(() => {
+        throw new Error("permission denied")
+      })
+
+      // Suppress console.error for this test
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+
+      const { writeStoredToken } = await import("../api/oauth-store.js")
+
+      // Should not throw
+      expect(() => writeStoredToken({ accessToken: "at" })).not.toThrow()
+      expect(errorSpy).toHaveBeenCalled()
+      errorSpy.mockRestore()
+    })
+  })
+})

--- a/src/api/linear-api.ts
+++ b/src/api/linear-api.ts
@@ -9,10 +9,21 @@ import { readFileSync, renameSync, writeFileSync } from "node:fs"
 import { homedir } from "node:os"
 import { join } from "node:path"
 
+import { readStoredToken, writeStoredToken } from "./oauth-store.js"
+
 const LINEAR_GRAPHQL_URL = "https://api.linear.app/graphql"
 const LINEAR_OAUTH_TOKEN_URL = "https://api.linear.app/oauth/token"
 const CYRUS_CONFIG_PATH = join(homedir(), ".cyrus", "config.json")
 const REFRESH_BUFFER_MS = 60_000 // refresh 60s before expiry
+
+// Token refresh coalescing — prevents concurrent refreshes from consuming the same single-use refresh token.
+// Linear refresh tokens are single-use: each refresh returns a new one and invalidates the old.
+interface RefreshResult {
+  accessToken: string
+  refreshToken?: string
+  expiresAt: number
+}
+const pendingRefreshes = new Map<string, Promise<RefreshResult>>()
 
 export type ActivityContent =
   | { type: "thought"; body: string }
@@ -23,21 +34,32 @@ export type ActivityContent =
 
 /**
  * Resolve Linear access token from multiple sources.
- * Can read from Cyrus's config.json to reuse existing OAuth tokens.
+ * Priority: plugin config > plugin-local store > Cyrus config > env var.
  */
 export function resolveLinearToken(pluginConfig?: Record<string, unknown>): {
   accessToken: string | null
   refreshToken?: string
   expiresAt?: number
-  source: "config" | "env" | "cyrus" | "none"
+  source: "config" | "store" | "cyrus" | "env" | "none"
 } {
-  // 1. Plugin config
+  // 1. Plugin config (explicitly set token)
   const fromConfig = pluginConfig?.accessToken
   if (typeof fromConfig === "string" && fromConfig) {
     return { accessToken: fromConfig, source: "config" }
   }
 
-  // 2. Cyrus config (~/.cyrus/config.json) — reuse existing OAuth token
+  // 2. Plugin-local token store (~/.openclaw/plugins/linear-light/token.json)
+  const stored = readStoredToken()
+  if (stored) {
+    return {
+      accessToken: stored.accessToken,
+      refreshToken: stored.refreshToken,
+      expiresAt: stored.expiresAt,
+      source: "store",
+    }
+  }
+
+  // 3. Cyrus config (~/.cyrus/config.json) — reuse existing OAuth token
   try {
     const cyrusConfig = JSON.parse(readFileSync(CYRUS_CONFIG_PATH, "utf8"))
 
@@ -57,7 +79,7 @@ export function resolveLinearToken(pluginConfig?: Record<string, unknown>): {
     // Cyrus config not available
   }
 
-  // 3. Env var
+  // 4. Env var
   const fromEnv = process.env.LINEAR_ACCESS_TOKEN ?? process.env.LINEAR_API_KEY
   if (fromEnv) {
     return { accessToken: fromEnv, source: "env" }
@@ -97,6 +119,7 @@ export class LinearAgentApi {
 
   /**
    * Refresh the OAuth token if it has expired or is about to expire.
+   * Uses coalescing to prevent concurrent refreshes from consuming the same single-use refresh token.
    * Requires refreshToken, clientId, and clientSecret.
    */
   private async ensureValidToken(): Promise<void> {
@@ -104,6 +127,32 @@ export class LinearAgentApi {
     if (this.expiresAt == null) return
     if (Date.now() < this.expiresAt - REFRESH_BUFFER_MS) return
 
+    // Coalesce: if a refresh is already in flight for this client, await it and apply the result
+    const cacheKey = this.clientId
+    const pending = pendingRefreshes.get(cacheKey)
+    if (pending) {
+      const result = await pending
+      this.accessToken = result.accessToken
+      if (result.refreshToken) this.refreshToken = result.refreshToken
+      this.expiresAt = result.expiresAt
+      return
+    }
+
+    // Perform the refresh
+    const promise = this.doRefresh()
+    pendingRefreshes.set(cacheKey, promise)
+
+    try {
+      const result = await promise
+      this.accessToken = result.accessToken
+      if (result.refreshToken) this.refreshToken = result.refreshToken
+      this.expiresAt = result.expiresAt
+    } finally {
+      pendingRefreshes.delete(cacheKey)
+    }
+  }
+
+  private async doRefresh(): Promise<RefreshResult> {
     const res = await fetch(LINEAR_OAUTH_TOKEN_URL, {
       method: "POST",
       headers: {
@@ -112,9 +161,9 @@ export class LinearAgentApi {
       },
       body: new URLSearchParams({
         grant_type: "refresh_token",
-        client_id: this.clientId,
-        client_secret: this.clientSecret,
-        refresh_token: this.refreshToken,
+        client_id: this.clientId!,
+        client_secret: this.clientSecret!,
+        refresh_token: this.refreshToken!,
       }),
     })
 
@@ -129,19 +178,38 @@ export class LinearAgentApi {
       expires_in: number
     }
 
-    this.accessToken = data.access_token
-    if (data.refresh_token) this.refreshToken = data.refresh_token
-    this.expiresAt = Date.now() + data.expires_in * 1000
+    const result: RefreshResult = {
+      accessToken: data.access_token,
+      refreshToken: data.refresh_token,
+      expiresAt: Date.now() + data.expires_in * 1000,
+    }
+
+    this.accessToken = result.accessToken
+    if (result.refreshToken) this.refreshToken = result.refreshToken
+    this.expiresAt = result.expiresAt
 
     this.persistToken()
+    return result
   }
 
   /**
-   * Persist refreshed token back to Cyrus config to keep it in sync.
+   * Persist refreshed token to plugin-local store (and Cyrus config if sourced from there).
    */
   private persistToken(): void {
-    if (this.tokenSource !== "cyrus") return
+    // Always write to plugin-local store
+    writeStoredToken({
+      accessToken: this.accessToken,
+      refreshToken: this.refreshToken,
+      expiresAt: this.expiresAt,
+    })
 
+    // Also sync to Cyrus config if that's where the token came from
+    if (this.tokenSource === "cyrus") {
+      this.persistToCyrusConfig()
+    }
+  }
+
+  private persistToCyrusConfig(): void {
     try {
       const raw = readFileSync(CYRUS_CONFIG_PATH, "utf8")
       const store = JSON.parse(raw)

--- a/src/api/oauth-store.ts
+++ b/src/api/oauth-store.ts
@@ -1,0 +1,52 @@
+/**
+ * Plugin-local OAuth token storage.
+ *
+ * Reads/writes tokens from ~/.openclaw/plugins/linear-light/token.json
+ * using atomic write-then-rename to prevent corruption.
+ */
+
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs"
+import { homedir } from "node:os"
+import { join } from "node:path"
+
+const TOKEN_DIR = join(homedir(), ".openclaw", "plugins", "linear-light")
+const TOKEN_PATH = join(TOKEN_DIR, "token.json")
+
+export interface StoredToken {
+  accessToken: string
+  refreshToken?: string
+  expiresAt?: number
+}
+
+/**
+ * Read OAuth tokens from plugin-local storage.
+ * Returns null if no token file exists or is invalid.
+ */
+export function readStoredToken(): StoredToken | null {
+  try {
+    if (!existsSync(TOKEN_PATH)) return null
+    const raw = readFileSync(TOKEN_PATH, "utf8")
+    const data = JSON.parse(raw) as StoredToken
+    if (!data.accessToken) return null
+    return data
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Write OAuth tokens to plugin-local storage using atomic write-then-rename.
+ */
+export function writeStoredToken(token: StoredToken): void {
+  try {
+    if (!existsSync(TOKEN_DIR)) {
+      mkdirSync(TOKEN_DIR, { recursive: true })
+    }
+
+    const tmpPath = `${TOKEN_PATH}.tmp`
+    writeFileSync(tmpPath, JSON.stringify(token, null, 2), "utf8")
+    renameSync(tmpPath, TOKEN_PATH)
+  } catch (err) {
+    console.error(`Linear Light: failed to write token store: ${err}`)
+  }
+}

--- a/src/oauth-handler.ts
+++ b/src/oauth-handler.ts
@@ -1,0 +1,222 @@
+/**
+ * OAuth authorization flow handler for Linear Light.
+ *
+ * Provides:
+ * - handleOAuthInit: starts the OAuth flow (redirects to Linear authorize URL with PKCE)
+ * - handleOAuthCallback: exchanges authorization code for tokens, stores them locally
+ */
+
+import { createHash, randomBytes } from "node:crypto"
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk"
+
+import { writeStoredToken } from "./api/oauth-store.js"
+
+const LINEAR_AUTHORIZE_URL = "https://linear.app/oauth/authorize"
+const LINEAR_TOKEN_URL = "https://api.linear.app/oauth/token"
+const DEFAULT_SCOPES = "read,write"
+
+// In-flight PKCE state for CSRF protection
+const pendingStates = new Map<string, { codeVerifier: string; expiresAt: number }>()
+const STATE_TTL_MS = 600_000 // 10 minutes
+
+function cleanupExpiredStates(): void {
+  const now = Date.now()
+  for (const [key, val] of pendingStates) {
+    if (now > val.expiresAt) pendingStates.delete(key)
+  }
+}
+
+/**
+ * Read query string from a stream-based request URL.
+ */
+function getQueryParams(req: any): Record<string, string> {
+  const url = req.url as string
+  const qIndex = url.indexOf("?")
+  if (qIndex === -1) return {}
+  const search = url.slice(qIndex + 1)
+  const params: Record<string, string> = {}
+  for (const pair of search.split("&")) {
+    const eqIndex = pair.indexOf("=")
+    if (eqIndex === -1) continue
+    params[decodeURIComponent(pair.slice(0, eqIndex))] = decodeURIComponent(pair.slice(eqIndex + 1))
+  }
+  return params
+}
+
+/**
+ * Generate PKCE code verifier and challenge.
+ */
+function generatePKCE(): { codeVerifier: string; codeChallenge: string } {
+  const codeVerifier = randomBytes(32).toString("base64url")
+  const codeChallenge = createHash("sha256").update(codeVerifier).digest("base64url")
+  return { codeVerifier, codeChallenge }
+}
+
+/**
+ * Generate the Linear OAuth authorization URL with PKCE.
+ */
+export function generateAuthorizationURL(
+  clientId: string,
+  redirectUri: string,
+  opts?: { scopes?: string; state?: string },
+): { url: string; state: string; codeVerifier: string } {
+  const { codeVerifier, codeChallenge } = generatePKCE()
+  const state = opts?.state || randomBytes(16).toString("hex")
+  const scopes = opts?.scopes || DEFAULT_SCOPES
+
+  // Store PKCE verifier for callback validation
+  pendingStates.set(state, {
+    codeVerifier,
+    expiresAt: Date.now() + STATE_TTL_MS,
+  })
+
+  const params = new URLSearchParams({
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    response_type: "code",
+    scope: scopes,
+    state,
+    code_challenge: codeChallenge,
+    code_challenge_method: "S256",
+    actor: "app",
+  })
+
+  return {
+    url: `${LINEAR_AUTHORIZE_URL}?${params.toString()}`,
+    state,
+    codeVerifier,
+  }
+}
+
+/**
+ * Handle OAuth init — redirect the user to Linear's authorization page.
+ * Route: GET /linear-light/oauth/init
+ */
+export async function handleOAuthInit(api: OpenClawPluginApi, req: any, res: any): Promise<void> {
+  const config = api.pluginConfig as Record<string, unknown> | undefined
+  const clientId = (config?.linearClientId as string) || process.env.LINEAR_CLIENT_ID
+
+  if (!clientId) {
+    res.writeHead(400, { "Content-Type": "application/json" })
+    res.end(JSON.stringify({ error: "linearClientId not configured" }))
+    return
+  }
+
+  // Build redirect URI from the request host
+  const proto = req.headers["x-forwarded-proto"] || "https"
+  const host = req.headers.host || "localhost"
+  const redirectUri = `${proto}://${host}/linear-light/oauth/callback`
+
+  const { url, state } = generateAuthorizationURL(clientId, redirectUri)
+
+  api.logger.info(`Linear Light: OAuth init, state=${state.slice(0, 8)}...`)
+  res.writeHead(302, { Location: url })
+  res.end()
+}
+
+/**
+ * Handle OAuth callback — exchange authorization code for tokens.
+ * Route: GET /linear-light/oauth/callback
+ */
+export async function handleOAuthCallback(api: OpenClawPluginApi, req: any, res: any): Promise<void> {
+  const config = api.pluginConfig as Record<string, unknown> | undefined
+  const params = getQueryParams(req)
+
+  const { code, state, error } = params
+
+  if (error) {
+    api.logger.error(`Linear Light: OAuth callback error: ${error}`)
+    res.writeHead(400, { "Content-Type": "text/html" })
+    res.end(`<h1>OAuth Error</h1><p>${escapeHtml(error)}</p>`)
+    return
+  }
+
+  if (!(code && state)) {
+    res.writeHead(400, { "Content-Type": "text/html" })
+    res.end("<h1>OAuth Error</h1><p>Missing code or state parameter.</p>")
+    return
+  }
+
+  // Validate state (CSRF protection)
+  cleanupExpiredStates()
+  const pending = pendingStates.get(state)
+  if (!pending) {
+    api.logger.error("Linear Light: OAuth callback with invalid or expired state")
+    res.writeHead(400, { "Content-Type": "text/html" })
+    res.end("<h1>OAuth Error</h1><p>Invalid or expired state parameter.</p>")
+    return
+  }
+  pendingStates.delete(state)
+
+  const clientId = (config?.linearClientId as string) || process.env.LINEAR_CLIENT_ID
+  const clientSecret = (config?.linearClientSecret as string) || process.env.LINEAR_CLIENT_SECRET
+
+  if (!(clientId && clientSecret)) {
+    api.logger.error("Linear Light: OAuth callback but clientId/clientSecret not configured")
+    res.writeHead(500, { "Content-Type": "text/html" })
+    res.end("<h1>Configuration Error</h1><p>linearClientId and linearClientSecret must be configured.</p>")
+    return
+  }
+
+  // Build redirect URI (must match the one used in init)
+  const proto = req.headers["x-forwarded-proto"] || "https"
+  const host = req.headers.host || "localhost"
+  const redirectUri = `${proto}://${host}/linear-light/oauth/callback`
+
+  // Exchange code for tokens
+  try {
+    const tokenRes = await fetch(LINEAR_TOKEN_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Accept: "application/json",
+      },
+      body: new URLSearchParams({
+        grant_type: "authorization_code",
+        code,
+        redirect_uri: redirectUri,
+        client_id: clientId,
+        client_secret: clientSecret,
+        code_verifier: pending.codeVerifier,
+      }),
+    })
+
+    if (!tokenRes.ok) {
+      const errorBody = await tokenRes.text()
+      api.logger.error(`Linear Light: token exchange failed (${tokenRes.status}): ${errorBody}`)
+      res.writeHead(502, { "Content-Type": "text/html" })
+      res.end(`<h1>Token Exchange Failed</h1><p>Linear returned ${tokenRes.status}.</p>`)
+      return
+    }
+
+    const tokenData = (await tokenRes.json()) as {
+      access_token: string
+      refresh_token?: string
+      expires_in: number
+    }
+
+    // Store tokens in plugin-local storage
+    writeStoredToken({
+      accessToken: tokenData.access_token,
+      refreshToken: tokenData.refresh_token,
+      expiresAt: Date.now() + tokenData.expires_in * 1000,
+    })
+
+    api.logger.info("Linear Light: OAuth token obtained and stored successfully")
+
+    res.writeHead(200, { "Content-Type": "text/html" })
+    res.end(`
+      <h1>OAuth Setup Complete</h1>
+      <p>Linear Light is now connected. You can close this page.</p>
+      <script>window.close()</script>
+    `)
+  } catch (err) {
+    api.logger.error(`Linear Light: OAuth callback exception: ${err}`)
+    res.writeHead(500, { "Content-Type": "text/html" })
+    res.end("<h1>Internal Error</h1><p>Failed to complete OAuth flow.</p>")
+  }
+}
+
+function escapeHtml(str: string): string {
+  return str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;")
+}


### PR DESCRIPTION
Assignee: @QiuYi111 ([qiuyi200311](https://linear.app/jingyi-dev/profiles/qiuyi200311))

## Summary

- **OAuth callback route** (`/linear-light/oauth/callback`) — exchanges authorization code for tokens using PKCE, stores them in plugin-local storage
- **OAuth init route** (`/linear-light/oauth/init`) — redirects to Linear's authorize URL with `actor=app` for bot identity
- **Plugin-local token storage** at `~/.openclaw/plugins/linear-light/token.json` with atomic write-then-rename
- **Token refresh coalescing** via `pendingRefreshes` map — prevents concurrent refreshes from consuming the same single-use refresh token
- **Degraded mode** — OAuth routes register even without a token, with helpful log message pointing to `/linear-light/oauth/init`

## Implementation

- `src/api/oauth-store.ts` — read/write token store with atomic writes
- `src/oauth-handler.ts` — PKCE flow, CSRF state validation, code-to-token exchange
- `src/api/linear-api.ts` — updated `resolveLinearToken` priority (config > store > cyrus > env), refresh coalescing, `persistToken` writes to store
- `index.ts` — OAuth routes always registered; webhook/tools only registered when token available

## Testing

- 99 tests passing, coverage above thresholds (90% stmts, 78% branches, 90% funcs, 92% lines)
- New test files: `oauth-handler.test.ts` (11 tests), `oauth-store.test.ts` (7 tests)
- Updated: `linear-api.test.ts` (store source, coalescing), `index.test.ts` (OAuth routes without token)

Closes DEV-116

---

> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a "changes requested" review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->