### PR TITLE
fix: restrict file permissions on OAuth token store

### DIFF
--- a/src/__test__/oauth-store.test.ts
+++ b/src/__test__/oauth-store.test.ts
@@ -65,7 +65,10 @@ describe("oauth-store", () => {
 
       writeStoredToken({ accessToken: "at-new" })
 
-      expect(mockMkdirSync).toHaveBeenCalledWith(expect.stringContaining("linear-light"), { recursive: true })
+      expect(mockMkdirSync).toHaveBeenCalledWith(expect.stringContaining("linear-light"), {
+        recursive: true,
+        mode: 0o700,
+      })
     })
 
     it("writes token atomically (tmp + rename)", async () => {
@@ -79,9 +82,15 @@ describe("oauth-store", () => {
       })
 
       expect(mockWriteFileSync).toHaveBeenCalledTimes(1)
-      const [tmpPath, content] = mockWriteFileSync.mock.calls[0]
+      const [tmpPath, content, options] = mockWriteFileSync.mock.calls[0] as [
+        string,
+        string,
+        { encoding: string; mode: number },
+      ]
       expect(tmpPath).toMatch(/\.tmp$/)
       expect(JSON.parse(content).accessToken).toBe("at-new")
+      expect(options.mode).toBe(0o600)
+      expect(options.encoding).toBe("utf8")
       expect(mockRenameSync).toHaveBeenCalledWith(tmpPath, expect.stringContaining("token.json"))
     })
 

--- a/src/api/oauth-store.ts
+++ b/src/api/oauth-store.ts
@@ -40,11 +40,11 @@ export function readStoredToken(): StoredToken | null {
 export function writeStoredToken(token: StoredToken): void {
   try {
     if (!existsSync(TOKEN_DIR)) {
-      mkdirSync(TOKEN_DIR, { recursive: true })
+      mkdirSync(TOKEN_DIR, { recursive: true, mode: 0o700 })
     }
 
     const tmpPath = `${TOKEN_PATH}.tmp`
-    writeFileSync(tmpPath, JSON.stringify(token, null, 2), "utf8")
+    writeFileSync(tmpPath, JSON.stringify(token, null, 2), { encoding: "utf8", mode: 0o600 })
     renameSync(tmpPath, TOKEN_PATH)
   } catch (err) {
     console.error(`Linear Light: failed to write token store: ${err}`)


### PR DESCRIPTION
Assignee: @QiuYi111 ([qiuyi200311](https://linear.app/jingyi-dev/profiles/qiuyi200311))

## Summary

Fixes a credential exposure vulnerability where OAuth access tokens and refresh tokens stored at `~/.openclaw/plugins/linear-light/token.json` were world-readable on Unix systems.

## Changes

- `src/api/oauth-store.ts`: Set directory permissions to `0o700` in `mkdirSync` and file permissions to `0o600` in `writeFileSync`
- `src/__test__/oauth-store.test.ts`: Updated test assertions to verify the new permission modes

## Testing

- 121 tests passing, all coverage thresholds met (≥90%)
- `oauth-store.ts` at 100% coverage

Closes DEV-120

---

> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a "changes requested" review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->