### PR TITLE
fix: add TTL-based expiry to activeRuns to prevent permanent deadlocks

### DIFF
--- a/src/__test__/webhook-handler.test.ts
+++ b/src/__test__/webhook-handler.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { makeAgentSessionCreated, makeAgentSessionPrompted, signPayload } from "./fixtures"
 
+// Cache the real Date.now so we can restore after fake timer tests
+const realDateNow = Date.now
+
 // ---------------------------------------------------------------------------
 // Webhook handler unit tests
 // ---------------------------------------------------------------------------
@@ -1109,6 +1112,81 @@ describe("handleWebhook", () => {
       await handleWebhook(api, req, res)
 
       expect(res.writeHead).toHaveBeenCalledWith(200, expect.any(Object))
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  describe("TTL-based activeRuns expiry", () => {
+    // -----------------------------------------------------------------------
+
+    afterEach(() => {
+      Date.now = realDateNow
+    })
+
+    it("expired activeRuns entry allows re-dispatch after TTL", async () => {
+      const { handleWebhook, ACTIVE_RUN_TTL_MS } = await import("../webhook-handler.js")
+      const api = makeApi()
+
+      // First dispatch — agent starts, session key recorded
+      const now = Date.now()
+      const payload1 = uniqueCreated()
+      const { req: req1, res: res1 } = makeSignedReq(payload1, SECRET)
+      await handleWebhook(api, req1, res1)
+      expect(res1.writeHead).toHaveBeenCalledWith(200, expect.any(Object))
+      expect(mockSubagentRun).toHaveBeenCalledTimes(1)
+
+      // Simulate time passing beyond TTL (crash scenario — clearActiveRun never called)
+      const expiredTime = now + ACTIVE_RUN_TTL_MS + 1000
+      Date.now = () => expiredTime
+
+      // Second dispatch for same issue (different session ID to bypass dedup)
+      // Should succeed because the stale entry was swept
+      mockSubagentRun.mockClear()
+      const n = uid++
+      const payload2 = makeAgentSessionCreated({
+        createdAt: `2099-06-01T00:00:${String(n).padStart(2, "0")}.000Z`,
+        agentSession: {
+          ...makeAgentSessionCreated().agentSession,
+          id: `sess-ttl-${n}`,
+          issue: payload1.agentSession.issue,
+        },
+      })
+      const { req: req2, res: res2 } = makeSignedReq(payload2, SECRET)
+      await handleWebhook(api, req2, res2)
+
+      expect(res2.writeHead).toHaveBeenCalledWith(200, expect.any(Object))
+      expect(mockSubagentRun).toHaveBeenCalledTimes(1)
+    })
+
+    it("does NOT re-dispatch before TTL expires", async () => {
+      const { handleWebhook, ACTIVE_RUN_TTL_MS } = await import("../webhook-handler.js")
+      const api = makeApi()
+
+      const now = Date.now()
+      const payload1 = uniqueCreated()
+      const { req: req1, res: res1 } = makeSignedReq(payload1, SECRET)
+      await handleWebhook(api, req1, res1)
+      expect(mockSubagentRun).toHaveBeenCalledTimes(1)
+
+      // Advance time but stay within TTL
+      Date.now = () => now + ACTIVE_RUN_TTL_MS - 1000
+
+      mockSubagentRun.mockClear()
+      const n = uid++
+      const payload2 = makeAgentSessionCreated({
+        createdAt: `2099-07-01T00:00:${String(n).padStart(2, "0")}.000Z`,
+        agentSession: {
+          ...makeAgentSessionCreated().agentSession,
+          id: `sess-early-${n}`,
+          issue: payload1.agentSession.issue,
+        },
+      })
+      const { req: req2, res: res2 } = makeSignedReq(payload2, SECRET)
+      await handleWebhook(api, req2, res2)
+
+      // activeRuns still has the entry — blocked
+      expect(res2.writeHead).toHaveBeenCalledWith(200, expect.any(Object))
+      expect(mockSubagentRun).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/webhook-handler.ts
+++ b/src/webhook-handler.ts
@@ -24,12 +24,28 @@ let lastSweep = Date.now()
 
 // Concurrent run guard — prevents two webhooks for the same issue from spawning
 // parallel agent sessions (e.g. "created" followed quickly by "prompted").
-const activeRuns = new Set<string>()
+// Uses timestamps so stale entries expire after ACTIVE_RUN_TTL_MS even if
+// clearActiveRun is never called (e.g. process crash, hook registration failure).
+const activeRuns = new Map<string, number>()
+export const ACTIVE_RUN_TTL_MS = 30 * 60_000 // 30 minutes
 
 export function clearActiveRun(sessionKey: string, prefix = "linear:"): void {
   if (sessionKey.startsWith(prefix)) {
     activeRuns.delete(sessionKey)
   }
+}
+
+function isSessionActive(sessionKey: string): boolean {
+  const now = Date.now()
+  // Sweep expired entries on every check
+  for (const [k, ts] of activeRuns) {
+    if (now - ts > ACTIVE_RUN_TTL_MS) activeRuns.delete(k)
+  }
+  return activeRuns.has(sessionKey)
+}
+
+function markSessionActive(sessionKey: string): void {
+  activeRuns.set(sessionKey, Date.now())
 }
 
 function wasRecentlyProcessed(key: string): boolean {
@@ -240,11 +256,11 @@ async function handleSessionCreated(
   const sessionKey = `${sessionPrefix}${issueId}`
 
   // Guard: skip if an agent is already running for this issue
-  if (activeRuns.has(sessionKey)) {
+  if (isSessionActive(sessionKey)) {
     api.logger.info(`Linear Light: agent already running for ${issue.identifier}, skipping`)
     return
   }
-  activeRuns.add(sessionKey)
+  markSessionActive(sessionKey)
 
   // Determine prompt content
   // If triggered by @mention, use the comment body
@@ -363,11 +379,11 @@ async function handleSessionPrompted(
   const sessionKey = `${sessionPrefix}${issueId}`
 
   // Guard: skip if an agent is already running for this issue
-  if (activeRuns.has(sessionKey)) {
+  if (isSessionActive(sessionKey)) {
     api.logger.info(`Linear Light: agent already running for ${session.issue.identifier}, skipping follow-up`)
     return
   }
-  activeRuns.add(sessionKey)
+  markSessionActive(sessionKey)
 
   // Ensure agent session ID is available for activity emission
   const agentSessionId = session.id as string | undefined
@@ -419,11 +435,11 @@ async function handleCommentCreate(
   const sessionKey = `${sessionPrefix}${issueId}`
 
   // Guard: skip if an agent is already running for this issue
-  if (activeRuns.has(sessionKey)) {
+  if (isSessionActive(sessionKey)) {
     api.logger.info(`Linear Light: agent already running for issue ${issueId}, skipping`)
     return
   }
-  activeRuns.add(sessionKey)
+  markSessionActive(sessionKey)
 
   api.logger.info(`Linear Light: comment trigger detected (fallback path) for issue ${issueId}`)
 


### PR DESCRIPTION
Assignee: @QiuYi111 ([qiuyi200311](https://linear.app/jingyi-dev/profiles/qiuyi200311))

## Summary

Replace `activeRuns` `Set<string>` with `Map<string, number>` storing timestamps, and sweep expired entries on every check. This prevents permanent deadlocks when `clearActiveRun` is never called (process crash, agent killed, hook registration failure).

## Problem

The `activeRuns` Set acts as a concurrency guard to prevent parallel agent sessions for the same issue. If `onSubagentEnded` is never called, the session key is never removed — permanently blocking the issue until process restart.

## Implementation

- Replaced `Set<string>` with `Map<string, number>` (key → timestamp)
- Added `isSessionActive(key)` — sweeps entries older than `ACTIVE_RUN_TTL_MS` on every check, then returns whether the key exists
- Added `markSessionActive(key)` — records `Date.now()` in the map
- TTL is 30 minutes (`ACTIVE_RUN_TTL_MS`), exported for configurability
- `clearActiveRun()` preserved for normal cleanup paths (catch blocks)
- Updated all 3 handler functions (`handleSessionCreated`, `handleSessionPrompted`, `handleCommentCreate`)

## Testing

- Existing activeRuns guard tests continue to pass (123 total tests)
- 2 new TTL expiry tests:
  - Expired entry allows re-dispatch (crash recovery)
  - Non-expired entry still blocks concurrent runs
- Coverage: ≥90% across all metrics
- `lint` clean, `typecheck` clean

Closes #78

---

> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a "changes requested" review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->