### PR TITLE
fix: filter bot-authored comments to prevent self-triggering loops

### DIFF
--- a/src/__test__/webhook-handler.test.ts
+++ b/src/__test__/webhook-handler.test.ts
@@ -957,6 +957,150 @@ describe("handleWebhook", () => {
       expect(mockSubagentRun).not.toHaveBeenCalled()
     })
 
+    it("skips comments authored by the bot (self-trigger prevention)", async () => {
+      const { handleWebhook } = await import("../webhook-handler.js")
+      const botUserId = "bot-user-uuid-001"
+      const api = makeApi({ accessToken: "lin_test_token", botUserId })
+
+      const payload = {
+        type: "Comment",
+        action: "create",
+        createdAt: `2026-04-01T16:00:${String(uid++).padStart(2, "0")}.000Z`,
+        actor: { id: botUserId, name: "Linus Bot" },
+        data: {
+          id: `comment-bot-${uid}`,
+          body: "@Linus I've completed the fix as requested",
+          issue: { id: `issue-bot-${uid}` },
+        },
+      }
+      const { req, res } = makeSignedReq(payload, SECRET)
+
+      await handleWebhook(api, req, res)
+
+      expect(res.writeHead).toHaveBeenCalledWith(200, expect.any(Object))
+      expect(mockSubagentRun).not.toHaveBeenCalled()
+    })
+
+    it("processes comments from non-bot users even when botUserId is configured", async () => {
+      const { handleWebhook } = await import("../webhook-handler.js")
+      const api = makeApi({ accessToken: "lin_test_token", botUserId: "bot-user-uuid-001" })
+
+      const commentIssueId = `issue-nonbot-${uid}`
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            data: {
+              issue: {
+                id: commentIssueId,
+                identifier: "ENG-66",
+                title: "Non-Bot Comment",
+                description: "Test",
+                url: "https://linear.app/eng/issue/ENG-66",
+                state: { name: "Todo", type: "unstarted" },
+                creator: null,
+                assignee: null,
+                labels: { nodes: [] },
+                team: { id: "team-001", key: "ENG", name: "Engineering" },
+                comments: { nodes: [] },
+                project: null,
+              },
+            },
+          }),
+      })
+
+      const payload = {
+        type: "Comment",
+        action: "create",
+        createdAt: `2026-04-01T16:00:${String(uid++).padStart(2, "0")}.000Z`,
+        actor: { id: "human-user-uuid-001", name: "Alice" },
+        data: {
+          id: `comment-nonbot-${uid}`,
+          body: "@Linus can you look at this?",
+          issue: { id: commentIssueId },
+        },
+      }
+      const { req, res } = makeSignedReq(payload, SECRET)
+
+      await handleWebhook(api, req, res)
+
+      expect(res.writeHead).toHaveBeenCalledWith(200, expect.any(Object))
+      expect(mockSubagentRun).toHaveBeenCalled()
+    })
+
+    it("processes comments when botUserId is not configured (backward compatible)", async () => {
+      const { handleWebhook } = await import("../webhook-handler.js")
+      const api = makeApi({ accessToken: "lin_test_token" })
+      // No botUserId in config
+
+      const commentIssueId = `issue-nobbotid-${uid}`
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            data: {
+              issue: {
+                id: commentIssueId,
+                identifier: "ENG-55",
+                title: "No BotUserId",
+                description: "Test",
+                url: "https://linear.app/eng/issue/ENG-55",
+                state: { name: "Todo", type: "unstarted" },
+                creator: null,
+                assignee: null,
+                labels: { nodes: [] },
+                team: { id: "team-001", key: "ENG", name: "Engineering" },
+                comments: { nodes: [] },
+                project: null,
+              },
+            },
+          }),
+      })
+
+      const payload = {
+        type: "Comment",
+        action: "create",
+        createdAt: `2026-04-01T17:00:${String(uid++).padStart(2, "0")}.000Z`,
+        actor: { id: "some-user-001", name: "Anyone" },
+        data: {
+          id: `comment-nobbotid-${uid}`,
+          body: "@Linus help me",
+          issue: { id: commentIssueId },
+        },
+      }
+      const { req, res } = makeSignedReq(payload, SECRET)
+
+      await handleWebhook(api, req, res)
+
+      expect(res.writeHead).toHaveBeenCalledWith(200, expect.any(Object))
+      expect(mockSubagentRun).toHaveBeenCalled()
+    })
+
+    it("skips bot comments when actor has no id but matches by name (edge case with missing actor.id)", async () => {
+      const { handleWebhook } = await import("../webhook-handler.js")
+      const api = makeApi({ accessToken: "lin_test_token", botUserId: "bot-user-uuid-001" })
+
+      // Actor without id field — should NOT be filtered (no id to compare)
+      const payload = {
+        type: "Comment",
+        action: "create",
+        createdAt: `2026-04-01T18:00:${String(uid++).padStart(2, "0")}.000Z`,
+        actor: { name: "Linus Bot" },
+        data: {
+          id: `comment-noactorid-${uid}`,
+          body: "@Linus this comment has no actor.id",
+          issue: { id: `issue-noactorid-${uid}` },
+        },
+      }
+      const { req, res } = makeSignedReq(payload, SECRET)
+
+      await handleWebhook(api, req, res)
+
+      // Without actor.id, the filter can't match — so it passes through
+      // but won't dispatch because no token was mocked for fetch
+      expect(res.writeHead).toHaveBeenCalledWith(200, expect.any(Object))
+    })
+
     it("handleCommentCreate blocks when agent already running from created event (cross-type activeRuns)", async () => {
       const { handleWebhook } = await import("../webhook-handler.js")
       const api = makeApi({ accessToken: "lin_test_token" })

--- a/src/webhook-handler.ts
+++ b/src/webhook-handler.ts
@@ -414,6 +414,17 @@ async function handleCommentCreate(
     return
   }
 
+  // Skip comments authored by the bot itself to prevent self-triggering loops.
+  // Linear webhooks include an `actor` field identifying who triggered the event.
+  const botUserId = (config?.botUserId as string) || process.env.LINEAR_BOT_USER_ID
+  if (botUserId) {
+    const actorId = payload.actor?.id as string | undefined
+    if (actorId && actorId === botUserId) {
+      api.logger.debug?.(`Linear Light: skipping bot-authored comment (actor=${actorId})`)
+      return
+    }
+  }
+
   const issueId = comment.issue.id
   const sessionPrefix = (config?.sessionPrefix as string) || "linear:"
   const sessionKey = `${sessionPrefix}${issueId}`


### PR DESCRIPTION
Assignee: @QiuYi111 ([qiuyi200311](https://linear.app/jingyi-dev/profiles/qiuyi200311))

## Summary

Filter out comments authored by the bot/agent user in the `handleCommentCreate` fallback path to prevent infinite self-triggering loops.

Previously, if the agent posted a comment containing the trigger text (e.g., "Linus"), it could re-trigger itself because the dedup map only prevents exact event ID duplicates. With a new event ID per webhook, an infinite loop was possible: agent posts comment → webhook fires → agent runs → posts another comment → repeat.

## Implementation

Added a bot identity check in `handleCommentCreate` (`src/webhook-handler.ts:417-426`):
- Reads `botUserId` from plugin config or `LINEAR_BOT_USER_ID` env var
- Compares `payload.actor.id` (Linear webhook actor field) against the configured bot user ID
- Silently skips bot-authored comments before dispatching to the agent
- Fully backward compatible — when `botUserId` is not configured, no filtering occurs

## Testing

- 4 new tests covering bot filtering: bot-authored skip, non-bot passthrough, backward compatibility, edge case with missing actor.id
- All 125 tests passing
- Coverage >= 90% on all thresholds

Closes DEV-122

---

> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a "changes requested" review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->