### PR TITLE
fix: add type guards on webhook body fields

### DIFF
--- a/src/__test__/webhook-handler.test.ts
+++ b/src/__test__/webhook-handler.test.ts
@@ -365,6 +365,148 @@ describe("handleWebhook", () => {
   })
 
   // -----------------------------------------------------------------------
+  describe("malformed payload type guards", () => {
+    // -----------------------------------------------------------------------
+
+    it("handleSessionCreated skips when issue.id is missing", async () => {
+      const { handleWebhook } = await import("../webhook-handler.js")
+      const api = makeApi()
+      const n = uid++
+      const payload = makeAgentSessionCreated({
+        createdAt: `2099-07-01T00:00:${String(n).padStart(2, "0")}.000Z`,
+        agentSession: {
+          id: `sess-malformed-${n}`,
+          issue: {
+            id: undefined,
+            identifier: `ENG-${n + 100}`,
+            title: `Malformed ${n}`,
+            description: "Missing id",
+            url: "https://linear.app/eng/issue/ENG-0",
+            team: { id: "team-001", key: "ENG", name: "Engineering" },
+          },
+        },
+      })
+      const { req, res } = makeSignedReq(payload, SECRET)
+
+      await handleWebhook(api, req, res)
+
+      expect(res.writeHead).toHaveBeenCalledWith(200, expect.any(Object))
+      expect(mockSubagentRun).not.toHaveBeenCalled()
+      expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining("malformed session payload"))
+    })
+
+    it("handleSessionCreated skips when issue.title is missing", async () => {
+      const { handleWebhook } = await import("../webhook-handler.js")
+      const api = makeApi()
+      const n = uid++
+      const payload = makeAgentSessionCreated({
+        createdAt: `2099-07-02T00:00:${String(n).padStart(2, "0")}.000Z`,
+        agentSession: {
+          id: `sess-malformed-${n}`,
+          issue: {
+            id: `issue-malformed-${n}`,
+            identifier: `ENG-${n + 100}`,
+            title: undefined,
+            description: "Missing title",
+            url: "https://linear.app/eng/issue/ENG-0",
+            team: { id: "team-001", key: "ENG", name: "Engineering" },
+          },
+        },
+      })
+      const { req, res } = makeSignedReq(payload, SECRET)
+
+      await handleWebhook(api, req, res)
+
+      expect(res.writeHead).toHaveBeenCalledWith(200, expect.any(Object))
+      expect(mockSubagentRun).not.toHaveBeenCalled()
+      expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining("malformed session payload"))
+    })
+
+    it("handleSessionCreated skips when issue.identifier is missing", async () => {
+      const { handleWebhook } = await import("../webhook-handler.js")
+      const api = makeApi()
+      const n = uid++
+      const payload = makeAgentSessionCreated({
+        createdAt: `2099-07-03T00:00:${String(n).padStart(2, "0")}.000Z`,
+        agentSession: {
+          id: `sess-malformed-${n}`,
+          issue: {
+            id: `issue-malformed-${n}`,
+            identifier: undefined,
+            title: `Malformed ${n}`,
+            description: "Missing identifier",
+            url: "https://linear.app/eng/issue/ENG-0",
+            team: { id: "team-001", key: "ENG", name: "Engineering" },
+          },
+        },
+      })
+      const { req, res } = makeSignedReq(payload, SECRET)
+
+      await handleWebhook(api, req, res)
+
+      expect(res.writeHead).toHaveBeenCalledWith(200, expect.any(Object))
+      expect(mockSubagentRun).not.toHaveBeenCalled()
+      expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining("malformed session payload"))
+    })
+
+    it("handleSessionPrompted skips when issue.id is missing", async () => {
+      const { handleWebhook } = await import("../webhook-handler.js")
+      const api = makeApi()
+      const n = uid++
+      const payload = makeAgentSessionPrompted({
+        createdAt: `2099-08-01T00:00:${String(n).padStart(2, "0")}.000Z`,
+        agentSession: {
+          id: `sess-prompt-malformed-${n}`,
+          issue: {
+            id: undefined,
+            identifier: `ENG-${n + 100}`,
+            url: `https://linear.app/eng/issue/ENG-${n + 100}`,
+          },
+        },
+        agentActivity: {
+          content: { body: "follow up" },
+          signal: null,
+        },
+      })
+      const { req, res } = makeSignedReq(payload, SECRET)
+
+      await handleWebhook(api, req, res)
+
+      expect(res.writeHead).toHaveBeenCalledWith(200, expect.any(Object))
+      expect(mockSubagentRun).not.toHaveBeenCalled()
+      expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining("malformed prompted payload"))
+    })
+
+    it("handleSessionPrompted skips when issue.identifier is missing", async () => {
+      const { handleWebhook } = await import("../webhook-handler.js")
+      const api = makeApi()
+      const n = uid++
+      const payload = makeAgentSessionPrompted({
+        createdAt: `2099-08-02T00:00:${String(n).padStart(2, "0")}.000Z`,
+        agentSession: {
+          id: `sess-prompt-malformed-${n}`,
+          issue: {
+            id: `issue-prompt-malformed-${n}`,
+            identifier: undefined,
+            url: `https://linear.app/eng/issue/ENG-${n + 100}`,
+          },
+        },
+        agentActivity: {
+          content: { body: "follow up" },
+          signal: null,
+        },
+      })
+      const { req, res } = makeSignedReq(payload, SECRET)
+
+      await handleWebhook(api, req, res)
+
+      expect(res.writeHead).toHaveBeenCalledWith(200, expect.any(Object))
+      expect(mockSubagentRun).not.toHaveBeenCalled()
+      expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining("malformed prompted payload"))
+    })
+  })
+
+  // -----------------------------------------------------------------------
   describe("webhook processing errors", () => {
     // -----------------------------------------------------------------------
 

--- a/src/webhook-handler.ts
+++ b/src/webhook-handler.ts
@@ -234,6 +234,13 @@ async function handleSessionCreated(
   }
 
   const issue = session.issue
+
+  // Validate required issue fields — malformed payload would crash downstream
+  if (!(issue.id && issue.title && issue.identifier)) {
+    api.logger.warn("Linear Light: malformed session payload — missing issue.id/title/identifier")
+    return
+  }
+
   const comment = session.comment
   const issueId = issue.id
   const sessionPrefix = (config?.sessionPrefix as string) || "linear:"
@@ -349,6 +356,12 @@ async function handleSessionPrompted(
   const activity = payload.agentActivity
 
   if (!(session?.issue && activity?.content?.body)) {
+    return
+  }
+
+  // Validate required fields — malformed payload would crash downstream
+  if (!(session.issue.id && session.issue.identifier)) {
+    api.logger.warn("Linear Light: malformed prompted payload — missing issue.id/identifier")
     return
   }
 


### PR DESCRIPTION
Assignee: @QiuYi111 ([qiuyi200311](https://linear.app/jingyi-dev/profiles/qiuyi200311))

## Summary

Adds null checks for critical nested properties in webhook handlers to prevent unhandled `TypeError` crashes on malformed webhook payloads.

## Changes

- `handleSessionCreated`: validates `issue.id`, `issue.title`, `issue.identifier` after the existing `session?.issue` check; returns early with descriptive warning log for malformed payloads
- `handleSessionPrompted`: validates `issue.id` and `issue.identifier` after the existing guard; returns early with descriptive warning log

## Testing

- 5 new tests covering missing field scenarios (issue.id, issue.title, issue.identifier for created; issue.id, issue.identifier for prompted)
- All 126 tests passing
- Coverage: 91.07% statements / 93.24% lines (above 90% threshold)

Closes #84

---

> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a "changes requested" review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->