### PR TITLE
fix: OAuth redirect URI mismatch between init and callback

### DIFF
--- a/src/__test__/oauth-handler.test.ts
+++ b/src/__test__/oauth-handler.test.ts
@@ -265,4 +265,36 @@ describe("handleOAuthCallback", () => {
     expect(res.statusCode).toBe(500)
     expect(res.body).toContain("Internal Error")
   })
+
+  it("uses the stored redirect URI from init, not the callback request headers", async () => {
+    const { handleOAuthCallback, generateAuthorizationURL } = await import("../oauth-handler.js")
+
+    // Init with one host
+    generateAuthorizationURL("test-client-id", "https://original-host:8080/linear-light/oauth/callback")
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          access_token: "tok",
+          refresh_token: "ref",
+          expires_in: 3600,
+        }),
+    })
+
+    const api = makeApi()
+    // Callback arrives via a different proxy/host — should still use the stored URI
+    const req = makeReq("/linear-light/oauth/callback?code=test-code&state=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", {
+      host: "different-host:9090",
+      "x-forwarded-proto": "http",
+    })
+    const res = makeRes()
+
+    await handleOAuthCallback(api, req, res)
+
+    expect(res.statusCode).toBe(200)
+    // Verify the token exchange used the original redirect URI
+    const fetchBody = mockFetch.mock.calls[0][1]?.body as URLSearchParams
+    expect(fetchBody.get("redirect_uri")).toBe("https://original-host:8080/linear-light/oauth/callback")
+  })
 })

--- a/src/oauth-handler.ts
+++ b/src/oauth-handler.ts
@@ -16,7 +16,7 @@ const LINEAR_TOKEN_URL = "https://api.linear.app/oauth/token"
 const DEFAULT_SCOPES = "read,write"
 
 // In-flight PKCE state for CSRF protection
-const pendingStates = new Map<string, { codeVerifier: string; expiresAt: number }>()
+const pendingStates = new Map<string, { codeVerifier: string; redirectUri: string; expiresAt: number }>()
 const STATE_TTL_MS = 600_000 // 10 minutes
 
 function cleanupExpiredStates(): void {
@@ -64,9 +64,10 @@ export function generateAuthorizationURL(
   const state = opts?.state || randomBytes(16).toString("hex")
   const scopes = opts?.scopes || DEFAULT_SCOPES
 
-  // Store PKCE verifier for callback validation
+  // Store PKCE verifier and redirect URI for callback validation
   pendingStates.set(state, {
     codeVerifier,
+    redirectUri,
     expiresAt: Date.now() + STATE_TTL_MS,
   })
 
@@ -146,6 +147,7 @@ export async function handleOAuthCallback(api: OpenClawPluginApi, req: any, res:
     res.end("<h1>OAuth Error</h1><p>Invalid or expired state parameter.</p>")
     return
   }
+  const { codeVerifier, redirectUri } = pending
   pendingStates.delete(state)
 
   const clientId = (config?.linearClientId as string) || process.env.LINEAR_CLIENT_ID
@@ -157,11 +159,6 @@ export async function handleOAuthCallback(api: OpenClawPluginApi, req: any, res:
     res.end("<h1>Configuration Error</h1><p>linearClientId and linearClientSecret must be configured.</p>")
     return
   }
-
-  // Build redirect URI (must match the one used in init)
-  const proto = req.headers["x-forwarded-proto"] || "https"
-  const host = req.headers.host || "localhost"
-  const redirectUri = `${proto}://${host}/linear-light/oauth/callback`
 
   // Exchange code for tokens
   try {
@@ -177,7 +174,7 @@ export async function handleOAuthCallback(api: OpenClawPluginApi, req: any, res:
         redirect_uri: redirectUri,
         client_id: clientId,
         client_secret: clientSecret,
-        code_verifier: pending.codeVerifier,
+        code_verifier: codeVerifier,
       }),
     })
 


### PR DESCRIPTION
## Summary
- Store the `redirectUri` in the pending PKCE state during `handleOAuthInit` instead of reconstructing it from request headers in `handleOAuthCallback`
- Prevents `redirect_uri_mismatch` errors when init and callback requests arrive through different proxy paths/ports/headers

Closes DEV-124

## Test plan
- [x] All existing tests pass
- [x] New test verifies callback uses stored redirect URI even when request headers differ
- [x] lint, typecheck, coverage (≥90%) all pass