### PR TITLE
feat: add project-based memory persistence for agent sessions

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -24,11 +24,7 @@ import type { Logger } from "./src/api/linear-api.js"
 import { LinearAgentApi, resolveLinearToken } from "./src/api/linear-api.js"
 import { setLoopStoreLogger } from "./src/api/loop-store.js"
 import { setOauthStateStoreLogger } from "./src/api/oauth-state-store.js"
-import {
-  resolveProjectInfo,
-  saveProjectFile,
-  setProjectStoreConfig,
-} from "./src/api/project-store.js"
+import { resolveProjectInfo, saveProjectFile, setProjectStoreConfig } from "./src/api/project-store.js"
 import {
   resumePersistedLoops,
   setCompletionLoopConfig,
@@ -430,7 +426,10 @@ function createLinearTools(api: OpenClawPluginApi): AnyAgentTool[] {
             logger: api.logger as unknown as Logger,
           })
           if (!projectInfo) {
-            return { content: [{ type: "text", text: "Issue has no project — cannot save to project memory." }], details: {} }
+            return {
+              content: [{ type: "text", text: "Issue has no project — cannot save to project memory." }],
+              details: {},
+            }
           }
 
           const result = saveProjectFile(

--- a/index.ts
+++ b/index.ts
@@ -25,6 +25,11 @@ import { LinearAgentApi, resolveLinearToken } from "./src/api/linear-api.js"
 import { setLoopStoreLogger } from "./src/api/loop-store.js"
 import { setOauthStateStoreLogger } from "./src/api/oauth-state-store.js"
 import {
+  resolveProjectInfo,
+  saveProjectFile,
+  setProjectStoreConfig,
+} from "./src/api/project-store.js"
+import {
   resumePersistedLoops,
   setCompletionLoopConfig,
   setCompletionLoopDispatcher,
@@ -147,6 +152,9 @@ export default function register(api: OpenClawPluginApi) {
     logger: api.logger,
   })
   setLinearApi(sharedLinearApi)
+
+  // Initialize project store config (base path, git, etc.)
+  setProjectStoreConfig(config)
 
   // Register webhook endpoint
   api.registerHttpRoute({
@@ -378,6 +386,61 @@ function createLinearTools(api: OpenClawPluginApi): AnyAgentTool[] {
             content: [{ type: "text", text: results.length ? results.join("\n") : "No issues found" }],
             details: {},
           }
+        } catch (err) {
+          return { content: [{ type: "text", text: `Failed: ${err}` }], details: { status: "failed" } }
+        }
+      },
+    },
+    {
+      name: "project_memory_save",
+      label: "Project Memory Save",
+      description:
+        "Save/append content to a project memory file (CONTEXT.md, PLAN.md, or README.md). " +
+        "Also commits and pushes to git. Use this at the end of your session to persist work.",
+      parameters: {
+        type: "object" as const,
+        properties: {
+          issueId: { type: "string", description: "The Linear issue UUID" },
+          filename: {
+            type: "string",
+            description: "Target file: CONTEXT.md, PLAN.md, or README.md",
+            enum: ["CONTEXT.md", "PLAN.md", "README.md"],
+          },
+          content: { type: "string", description: "Full new content of the file (replaces existing)" },
+          mode: {
+            type: "string",
+            description: "Write mode: 'replace' overwrites, 'append' adds to end",
+            enum: ["replace", "append"],
+          },
+        },
+        required: ["issueId", "filename", "content"],
+      },
+      execute: async (
+        _tc: string,
+        {
+          issueId,
+          filename,
+          content,
+          mode = "replace",
+        }: { issueId: string; filename: string; content: string; mode?: string },
+      ) => {
+        try {
+          const issue = await linearApi.getIssueDetails(issueId)
+          const projectInfo = resolveProjectInfo(issue.project, {
+            logger: api.logger as unknown as Logger,
+          })
+          if (!projectInfo) {
+            return { content: [{ type: "text", text: "Issue has no project — cannot save to project memory." }], details: {} }
+          }
+
+          const result = saveProjectFile(
+            projectInfo.dirPath,
+            filename,
+            content,
+            mode as "replace" | "append",
+            api.logger as unknown as Logger,
+          )
+          return { content: [{ type: "text", text: result.message }], details: {} }
         } catch (err) {
           return { content: [{ type: "text", text: `Failed: ${err}` }], details: { status: "failed" } }
         }

--- a/src/__test__/index.test.ts
+++ b/src/__test__/index.test.ts
@@ -146,7 +146,7 @@ describe("plugin register()", () => {
     expect(hookNames).toContain("agent_end")
   })
 
-  it("registers 3 tools: linear_update_status, linear_get_issue, linear_search_issues", async () => {
+  it("registers 4 tools: linear_update_status, linear_get_issue, linear_search_issues, project_memory_save", async () => {
     const mod = await import("../../index.js")
     const api = makeApi()
 
@@ -156,7 +156,8 @@ describe("plugin register()", () => {
     expect(toolNames).toContain("linear_update_status")
     expect(toolNames).toContain("linear_get_issue")
     expect(toolNames).toContain("linear_search_issues")
-    expect(toolNames).toHaveLength(3)
+    expect(toolNames).toContain("project_memory_save")
+    expect(toolNames).toHaveLength(4)
   })
 
   it("registers channel plugin with correct id and capabilities", async () => {

--- a/src/__test__/index.test.ts
+++ b/src/__test__/index.test.ts
@@ -11,8 +11,12 @@ const mockLogger = {
   debug: vi.fn(),
 }
 
-// Mock fs for token resolution
+// Mock fs for token resolution and project-store
+const mockExistsSync = vi.fn(() => true)
+const mockMkdirSync = vi.fn()
 vi.mock("node:fs", () => ({
+  existsSync: mockExistsSync,
+  mkdirSync: mockMkdirSync,
   readFileSync: vi.fn(() => {
     throw new Error("no file")
   }),
@@ -50,6 +54,10 @@ vi.mock("openclaw/plugin-sdk", () => ({
     setRuntime: vi.fn(),
     getRuntime: vi.fn(() => null),
   })),
+}))
+
+vi.mock("node:child_process", () => ({
+  execSync: vi.fn(),
 }))
 
 // Mock fetch for Linear API calls
@@ -158,6 +166,57 @@ describe("plugin register()", () => {
     expect(toolNames).toContain("linear_search_issues")
     expect(toolNames).toContain("project_memory_save")
     expect(toolNames).toHaveLength(4)
+  })
+
+  it("project_memory_save tool returns error when getIssueDetails fails", async () => {
+    // getIssueDetails will fail because the real API token is used.
+    // This tests the catch block in the tool execute.
+    const mod = await import("../../index.js")
+    const api = makeApi()
+    mod.default(api)
+
+    const toolCall = api.registerTool.mock.calls.find((c: any) => c[0].name === "project_memory_save")
+    const tool = toolCall![0]
+    const result = await tool.execute("tc", {
+      issueId: "nonexistent-id",
+      filename: "CONTEXT.md",
+      content: "# Test",
+    })
+
+    // Should fail gracefully since the API call won't succeed
+    expect(result.details).toEqual({ status: "failed" })
+  })
+
+  it("project_memory_save tool succeeds when issue has project", async () => {
+    // Mock fetch to return a valid GraphQL response with a project
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          data: {
+            issue: {
+              id: "test-id",
+              identifier: "ENG-42",
+              title: "Test",
+              project: { id: "proj-1", name: "MyProject" },
+            },
+          },
+        }),
+    })
+
+    const mod = await import("../../index.js")
+    const api = makeApi()
+    mod.default(api)
+
+    const toolCall = api.registerTool.mock.calls.find((c: any) => c[0].name === "project_memory_save")
+    const tool = toolCall![0]
+    const result = await tool.execute("tc", {
+      issueId: "test-id",
+      filename: "CONTEXT.md",
+      content: "# Test context",
+    })
+
+    expect(result.content[0].text).toContain("Saved CONTEXT.md")
   })
 
   it("registers channel plugin with correct id and capabilities", async () => {

--- a/src/__test__/index.test.ts
+++ b/src/__test__/index.test.ts
@@ -176,7 +176,8 @@ describe("plugin register()", () => {
     mod.default(api)
 
     const toolCall = api.registerTool.mock.calls.find((c: any) => c[0].name === "project_memory_save")
-    const tool = toolCall![0]
+    if (!toolCall) throw new Error("tool not registered")
+    const tool = toolCall[0]
     const result = await tool.execute("tc", {
       issueId: "nonexistent-id",
       filename: "CONTEXT.md",
@@ -209,7 +210,8 @@ describe("plugin register()", () => {
     mod.default(api)
 
     const toolCall = api.registerTool.mock.calls.find((c: any) => c[0].name === "project_memory_save")
-    const tool = toolCall![0]
+    if (!toolCall) throw new Error("tool not registered")
+    const tool = toolCall[0]
     const result = await tool.execute("tc", {
       issueId: "test-id",
       filename: "CONTEXT.md",

--- a/src/__test__/linear-api.test.ts
+++ b/src/__test__/linear-api.test.ts
@@ -13,6 +13,8 @@ const mockReadFileSync = vi.fn()
 const mockWriteFileSync = vi.fn()
 const mockRenameSync = vi.fn()
 vi.mock("node:fs", () => ({
+  existsSync: vi.fn(() => false),
+  mkdirSync: vi.fn(),
   readFileSync: mockReadFileSync,
   writeFileSync: mockWriteFileSync,
   renameSync: mockRenameSync,

--- a/src/__test__/project-store.test.ts
+++ b/src/__test__/project-store.test.ts
@@ -46,6 +46,25 @@ describe("project-store", () => {
       const { slugifyProjectName } = await import("../api/project-store.js")
       expect(slugifyProjectName("!!! ???")).toBe("")
     })
+
+    it("appends project id hash when id is provided", async () => {
+      const { slugifyProjectName } = await import("../api/project-store.js")
+      const result = slugifyProjectName("My Project", "abc123")
+      expect(result).toMatch(/^my-project-[a-f0-9]{6}$/)
+    })
+
+    it("produces different slugs for colliding names with different ids", async () => {
+      const { slugifyProjectName } = await import("../api/project-store.js")
+      const slug1 = slugifyProjectName("A/B Project", "proj-aaa")
+      const slug2 = slugifyProjectName("AB Project", "proj-bbb")
+      expect(slug1).not.toBe(slug2)
+    })
+
+    it("falls back to proj-<hash> for empty-name projects with id", async () => {
+      const { slugifyProjectName } = await import("../api/project-store.js")
+      const result = slugifyProjectName("!!!", "abc123")
+      expect(result).toMatch(/^proj-[a-f0-9]{6}$/)
+    })
   })
 
   describe("getProjectDir", () => {
@@ -63,7 +82,7 @@ describe("project-store", () => {
 
       const result = ensureProjectDir("Test Project")
 
-      expect(result.slug).toBe("test-project")
+      expect(result.slug).toMatch(/^test-project$/)
       expect(result.dirPath).toMatch(/projects\/test-project$/)
       expect(mockMkdirSync).toHaveBeenCalledWith(result.dirPath, { recursive: true, mode: 0o700 })
       // 3 file writes: AGENTS.md, README.md, Context.md
@@ -88,7 +107,7 @@ describe("project-store", () => {
 
       const result = ensureProjectDir("Existing Project")
 
-      expect(result.slug).toBe("existing-project")
+      expect(result.slug).toMatch(/^existing-project$/)
       expect(mockMkdirSync).not.toHaveBeenCalled()
       expect(mockWriteFileSync).not.toHaveBeenCalled()
     })
@@ -225,8 +244,8 @@ describe("project-store", () => {
       expect(result).toEqual({
         id: "proj-1",
         name: "My Project",
-        slug: "my-project",
-        dirPath: expect.stringMatching(/projects\/my-project$/),
+        slug: expect.stringMatching(/^my-project-[a-f0-9]{6}$/),
+        dirPath: expect.stringMatching(/projects\/my-project-[a-f0-9]{6}$/),
       })
     })
   })

--- a/src/__test__/project-store.test.ts
+++ b/src/__test__/project-store.test.ts
@@ -57,7 +57,7 @@ describe("project-store", () => {
   })
 
   describe("ensureProjectDir", () => {
-    it("creates directory and files when they do not exist", async () => {
+    it("creates directory, all files, and issues/ when they do not exist", async () => {
       mockExistsSync.mockReturnValue(false)
       const { ensureProjectDir } = await import("../api/project-store.js")
 
@@ -65,13 +65,21 @@ describe("project-store", () => {
 
       expect(result.slug).toBe("test-project")
       expect(result.dirPath).toMatch(/projects\/test-project$/)
-      expect(mockMkdirSync).toHaveBeenCalledWith(result.dirPath, {
-        recursive: true,
-        mode: 0o700,
-      })
-      // Should create README.md and CONTEXT.md (2 writes + 2 renames)
-      expect(mockWriteFileSync).toHaveBeenCalledTimes(2)
-      expect(mockRenameSync).toHaveBeenCalledTimes(2)
+      expect(mockMkdirSync).toHaveBeenCalledWith(result.dirPath, { recursive: true, mode: 0o700 })
+      // 3 file writes: AGENTS.md, README.md, Context.md
+      expect(mockWriteFileSync).toHaveBeenCalledTimes(3)
+      expect(mockRenameSync).toHaveBeenCalledTimes(3)
+    })
+
+    it("creates issues/ subdirectory", async () => {
+      mockExistsSync.mockReturnValue(false)
+      const { ensureProjectDir } = await import("../api/project-store.js")
+
+      ensureProjectDir("Test Project")
+
+      const issuesMkdir = mockMkdirSync.mock.calls.find(([path]) => (path as string).endsWith("issues"))
+      expect(issuesMkdir).toBeDefined()
+      expect(issuesMkdir?.[1]).toEqual({ mode: 0o700 })
     })
 
     it("skips creation when directory already exists", async () => {
@@ -85,13 +93,43 @@ describe("project-store", () => {
       expect(mockWriteFileSync).not.toHaveBeenCalled()
     })
 
+    it("creates AGENTS.md with project rules and directory structure", async () => {
+      mockExistsSync.mockReturnValue(false)
+      const { ensureProjectDir } = await import("../api/project-store.js")
+
+      ensureProjectDir("My Proj")
+
+      const agentsCall = mockWriteFileSync.mock.calls.find(([path]) => (path as string).endsWith("AGENTS.md.tmp"))
+      expect(agentsCall).toBeDefined()
+      const content = agentsCall?.[1] as string
+      expect(content).toContain("Agent Rules")
+      expect(content).toContain("README.md")
+      expect(content).toContain("Context.md")
+      expect(content).toContain("issues/")
+      expect(content).toContain("AGENTS.md")
+    })
+
+    it("creates README.md with purpose and background sections", async () => {
+      mockExistsSync.mockReturnValue(false)
+      const { ensureProjectDir } = await import("../api/project-store.js")
+
+      ensureProjectDir("My Proj")
+
+      const readmeCall = mockWriteFileSync.mock.calls.find(([path]) => (path as string).endsWith("README.md.tmp"))
+      expect(readmeCall).toBeDefined()
+      const content = readmeCall?.[1] as string
+      expect(content).toContain("Purpose")
+      expect(content).toContain("Background")
+      // Should NOT contain the old issue table
+      expect(content).not.toContain("Issues")
+      expect(content).not.toContain("| Identifier |")
+    })
+
     it("includes project URL in README when provided", async () => {
       mockExistsSync.mockReturnValue(false)
       const { ensureProjectDir } = await import("../api/project-store.js")
 
-      ensureProjectDir("My Proj", {
-        projectUrl: "https://linear.app/test/project/my-proj",
-      })
+      ensureProjectDir("My Proj", { projectUrl: "https://linear.app/test/project/my-proj" })
 
       const readmeCall = mockWriteFileSync.mock.calls.find(([path]) => (path as string).endsWith("README.md.tmp"))
       expect(readmeCall).toBeDefined()
@@ -107,6 +145,21 @@ describe("project-store", () => {
       const readmeCall = mockWriteFileSync.mock.calls.find(([path]) => (path as string).endsWith("README.md.tmp"))
       expect(readmeCall).toBeDefined()
       expect(readmeCall?.[1]).not.toContain("Linear:")
+    })
+
+    it("creates Context.md with refined context sections", async () => {
+      mockExistsSync.mockReturnValue(false)
+      const { ensureProjectDir } = await import("../api/project-store.js")
+
+      ensureProjectDir("My Proj")
+
+      const contextCall = mockWriteFileSync.mock.calls.find(([path]) => (path as string).endsWith("Context.md.tmp"))
+      expect(contextCall).toBeDefined()
+      const content = contextCall?.[1] as string
+      expect(content).toContain("Context")
+      expect(content).toContain("Current State")
+      expect(content).toContain("Key Findings")
+      expect(content).toContain("Architecture Decisions")
     })
 
     it("logs creation when logger is provided", async () => {
@@ -130,8 +183,7 @@ describe("project-store", () => {
         expect(tmpPath).toMatch(/\.tmp$/)
         expect((opts as { mode: number }).mode).toBe(0o600)
       }
-      // Each write should be followed by a rename
-      expect(mockRenameSync).toHaveBeenCalledTimes(2)
+      expect(mockRenameSync).toHaveBeenCalledTimes(3)
     })
   })
 

--- a/src/__test__/project-store.test.ts
+++ b/src/__test__/project-store.test.ts
@@ -230,4 +230,78 @@ describe("project-store", () => {
       })
     })
   })
+
+  describe("syncIssueConversation", () => {
+    it("writes issue comments to issues/<identifier>.md", async () => {
+      mockExistsSync.mockReturnValue(true)
+      const { syncIssueConversation } = await import("../api/project-store.js")
+
+      const comments = [
+        { user: { name: "Alice" }, body: "Please fix this bug.", createdAt: "2026-04-01T10:00:00.000Z" },
+        { user: { name: "Bob" }, body: "Done, see PR #5.", createdAt: "2026-04-01T11:00:00.000Z" },
+      ]
+
+      syncIssueConversation("/projects/my-project", "ENG-42", comments)
+
+      const writeCall = mockWriteFileSync.mock.calls.find(([path]) => (path as string).endsWith("issues/ENG-42.md.tmp"))
+      expect(writeCall).toBeDefined()
+      const content = writeCall?.[1] as string
+      expect(content).toContain("# ENG-42 — Conversation")
+      expect(content).toContain("Alice")
+      expect(content).toContain("Please fix this bug.")
+      expect(content).toContain("Bob")
+      expect(content).toContain("Done, see PR #5.")
+    })
+
+    it("writes placeholder when no comments", async () => {
+      mockExistsSync.mockReturnValue(true)
+      const { syncIssueConversation } = await import("../api/project-store.js")
+
+      syncIssueConversation("/projects/my-project", "ENG-99", [])
+
+      const writeCall = mockWriteFileSync.mock.calls.find(([path]) => (path as string).endsWith("issues/ENG-99.md.tmp"))
+      expect(writeCall).toBeDefined()
+      expect(writeCall?.[1]).toContain("No comments yet")
+    })
+
+    it("creates issues/ directory if it does not exist", async () => {
+      mockExistsSync.mockReturnValue(false)
+      const { syncIssueConversation } = await import("../api/project-store.js")
+
+      syncIssueConversation("/projects/my-project", "ENG-42", [])
+
+      expect(mockMkdirSync).toHaveBeenCalledWith(
+        expect.stringContaining("issues"),
+        expect.objectContaining({ mode: 0o700 }),
+      )
+    })
+
+    it("handles null user name gracefully", async () => {
+      mockExistsSync.mockReturnValue(true)
+      const { syncIssueConversation } = await import("../api/project-store.js")
+
+      syncIssueConversation("/projects/my-project", "ENG-42", [
+        { user: null, body: "Anonymous comment", createdAt: "2026-04-01T10:00:00.000Z" },
+      ])
+
+      const writeCall = mockWriteFileSync.mock.calls.find(([path]) => (path as string).endsWith("issues/ENG-42.md.tmp"))
+      expect(writeCall?.[1]).toContain("Unknown")
+      expect(writeCall?.[1]).toContain("Anonymous comment")
+    })
+
+    it("logs sync when logger is provided", async () => {
+      mockExistsSync.mockReturnValue(true)
+      const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+      const { syncIssueConversation } = await import("../api/project-store.js")
+
+      syncIssueConversation(
+        "/projects/my-project",
+        "ENG-42",
+        [{ user: { name: "A" }, body: "Hi", createdAt: "2026-04-01T10:00:00.000Z" }],
+        { logger },
+      )
+
+      expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("synced 1 comments for ENG-42"))
+    })
+  })
 })

--- a/src/__test__/project-store.test.ts
+++ b/src/__test__/project-store.test.ts
@@ -7,13 +7,20 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 const mockExistsSync = vi.fn()
 const mockMkdirSync = vi.fn()
 const mockWriteFileSync = vi.fn()
+const mockReadFileSync = vi.fn()
 const mockRenameSync = vi.fn()
+const mockExecSync = vi.fn()
 
 vi.mock("node:fs", () => ({
   existsSync: mockExistsSync,
   mkdirSync: mockMkdirSync,
   writeFileSync: mockWriteFileSync,
+  readFileSync: mockReadFileSync,
   renameSync: mockRenameSync,
+}))
+
+vi.mock("node:child_process", () => ({
+  execSync: mockExecSync,
 }))
 
 describe("project-store", () => {
@@ -321,6 +328,161 @@ describe("project-store", () => {
       )
 
       expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("synced 1 comments for ENG-42"))
+    })
+  })
+
+  describe("getProjectDir", () => {
+    it("uses custom basePath when provided", async () => {
+      const { getProjectDir } = await import("../api/project-store.js")
+      const dir = getProjectDir("my-project", "/custom/path")
+      expect(dir).toBe("/custom/path/my-project")
+    })
+
+    it("falls back to config basePath when not provided", async () => {
+      const { getProjectDir, setProjectStoreConfig } = await import("../api/project-store.js")
+      setProjectStoreConfig({ enabled: true, basePath: "/default/path", autoGit: false })
+      // Re-import to get updated config
+      const dir = getProjectDir("test-slug")
+      expect(dir).toMatch(/test-slug$/) // Just verify it ends with the slug (config may not reset between tests)
+    })
+  })
+
+  describe("initGitRepo", () => {
+    it("initializes git repo and makes initial commit when .git does not exist", async () => {
+      mockExistsSync.mockReturnValue(false)
+      const { initGitRepo } = await import("../api/project-store.js")
+      const logger = { info: vi.fn(), warn: vi.fn() }
+
+      const result = initGitRepo("/projects/test", logger)
+
+      expect(result).toBe(true)
+      expect(mockExecSync).toHaveBeenCalledWith("git init", expect.objectContaining({ cwd: "/projects/test" }))
+      expect(mockExecSync).toHaveBeenCalledWith(
+        expect.stringContaining("git commit"),
+        expect.objectContaining({ cwd: "/projects/test" }),
+      )
+      expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("initialized git repo"))
+    })
+
+    it("skips when .git already exists", async () => {
+      mockExistsSync.mockImplementation((path: string) => path.endsWith(".git"))
+      const { initGitRepo } = await import("../api/project-store.js")
+
+      const result = initGitRepo("/projects/existing")
+
+      expect(result).toBe(false)
+      expect(mockExecSync).not.toHaveBeenCalled()
+    })
+
+    it("returns false on failure and logs warning", async () => {
+      mockExistsSync.mockReturnValue(false)
+      mockExecSync.mockImplementation(() => { throw new Error("git not found") })
+      const { initGitRepo } = await import("../api/project-store.js")
+      const logger = { info: vi.fn(), warn: vi.fn() }
+
+      const result = initGitRepo("/projects/fail", logger)
+
+      expect(result).toBe(false)
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("git init failed"))
+    })
+  })
+
+  describe("saveProjectFile", () => {
+    beforeEach(() => {
+      vi.clearAllMocks()
+      mockExistsSync.mockReturnValue(true)
+    })
+
+    it("writes file in replace mode", async () => {
+      const { saveProjectFile, setProjectStoreConfig } = await import("../api/project-store.js")
+      setProjectStoreConfig({ enabled: true, basePath: "/projects", autoGit: false })
+
+      const result = saveProjectFile("/projects/test", "CONTEXT.md", "new content")
+
+      expect(result.ok).toBe(true)
+      expect(result.message).toContain("Saved CONTEXT.md to /projects/test")
+      expect(mockWriteFileSync).toHaveBeenCalledWith("/projects/test/CONTEXT.md", "new content", "utf-8")
+    })
+
+    it("appends content in append mode when file exists", async () => {
+      mockReadFileSync.mockReturnValue("existing content")
+      const { saveProjectFile, setProjectStoreConfig } = await import("../api/project-store.js")
+      setProjectStoreConfig({ enabled: true, basePath: "/projects", autoGit: false })
+
+      const result = saveProjectFile("/projects/test", "CONTEXT.md", "appended", "append")
+
+      expect(result.ok).toBe(true)
+      expect(mockReadFileSync).toHaveBeenCalledWith("/projects/test/CONTEXT.md", "utf-8")
+      expect(mockWriteFileSync).toHaveBeenCalledWith("/projects/test/CONTEXT.md", "existing content\nappended", "utf-8")
+    })
+
+    it("creates directory when it does not exist", async () => {
+      mockExistsSync.mockImplementation((p: string) => p === "/projects/new/.git")
+      const { saveProjectFile, setProjectStoreConfig } = await import("../api/project-store.js")
+      setProjectStoreConfig({ enabled: true, basePath: "/projects", autoGit: false })
+
+      saveProjectFile("/projects/new", "README.md", "content")
+
+      expect(mockMkdirSync).toHaveBeenCalledWith("/projects/new", { recursive: true })
+    })
+
+    it("commits and pushes when autoGit is enabled", async () => {
+      mockExistsSync.mockImplementation((p: string) => p.endsWith(".git"))
+      mockExecSync.mockReturnValue("") // reset from previous test
+      const { saveProjectFile, setProjectStoreConfig } = await import("../api/project-store.js")
+      setProjectStoreConfig({ enabled: true, basePath: "/projects", autoGit: true })
+
+      const result = saveProjectFile("/projects/test", "CONTEXT.md", "content")
+
+      expect(result.ok).toBe(true)
+      expect(result.message).toContain("committed + pushed")
+      expect(mockExecSync).toHaveBeenCalledWith(
+        expect.stringContaining("git commit"),
+        expect.objectContaining({ cwd: "/projects/test" }),
+      )
+    })
+
+    it("initializes git repo within saveProjectFile when .git does not exist and autoGit is true", async () => {
+      // .git doesn't exist, so initGitRepo will be called
+      mockExistsSync.mockImplementation((p: string) => p === "/projects/test" || p === "/projects/test/CONTEXT.md")
+      mockExecSync.mockReturnValue("")
+      const { saveProjectFile, setProjectStoreConfig } = await import("../api/project-store.js")
+      const logger = { info: vi.fn(), warn: vi.fn() }
+      setProjectStoreConfig({ enabled: true, basePath: "/projects", autoGit: true })
+
+      const result = saveProjectFile("/projects/test", "CONTEXT.md", "content", "replace", logger)
+
+      expect(result.ok).toBe(true)
+      expect(result.message).toContain("committed + pushed")
+      // initGitRepo should have been called (git init + initial commit)
+      expect(mockExecSync).toHaveBeenCalledWith("git init", expect.objectContaining({ cwd: "/projects/test" }))
+    })
+
+    it("reports git failure but still succeeds", async () => {
+      mockExistsSync.mockReturnValue(true)
+      mockExecSync.mockImplementation(() => { throw new Error("push failed") })
+      const { saveProjectFile, setProjectStoreConfig } = await import("../api/project-store.js")
+      const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+      setProjectStoreConfig({ enabled: true, basePath: "/projects", autoGit: true })
+
+      const result = saveProjectFile("/projects/test", "CONTEXT.md", "content", "replace", logger)
+
+      expect(result.ok).toBe(true)
+      expect(result.message).toContain("git failed")
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("git commit failed"))
+    })
+
+    it("returns error on unexpected failure", async () => {
+      mockExistsSync.mockReturnValue(true)
+      mockWriteFileSync.mockImplementation(() => { throw new Error("disk full") })
+      const { saveProjectFile, setProjectStoreConfig } = await import("../api/project-store.js")
+      setProjectStoreConfig({ enabled: true, basePath: "/projects", autoGit: false })
+
+      const result = saveProjectFile("/projects/test", "CONTEXT.md", "content")
+
+      expect(result.ok).toBe(false)
+      expect(result.message).toContain("Failed")
+      expect(result.message).toContain("disk full")
     })
   })
 })

--- a/src/__test__/project-store.test.ts
+++ b/src/__test__/project-store.test.ts
@@ -1,0 +1,181 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+// ---------------------------------------------------------------------------
+// Project store unit tests
+// ---------------------------------------------------------------------------
+
+const mockExistsSync = vi.fn()
+const mockMkdirSync = vi.fn()
+const mockWriteFileSync = vi.fn()
+const mockRenameSync = vi.fn()
+
+vi.mock("node:fs", () => ({
+  existsSync: mockExistsSync,
+  mkdirSync: mockMkdirSync,
+  writeFileSync: mockWriteFileSync,
+  renameSync: mockRenameSync,
+}))
+
+describe("project-store", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe("slugifyProjectName", () => {
+    it("lowercases and replaces spaces with hyphens", async () => {
+      const { slugifyProjectName } = await import("../api/project-store.js")
+      expect(slugifyProjectName("My Project")).toBe("my-project")
+    })
+
+    it("handles already-lowercase names", async () => {
+      const { slugifyProjectName } = await import("../api/project-store.js")
+      expect(slugifyProjectName("ewl")).toBe("ewl")
+    })
+
+    it("collapses multiple special characters into single hyphen", async () => {
+      const { slugifyProjectName } = await import("../api/project-store.js")
+      expect(slugifyProjectName("API v2 -- Beta!!")).toBe("api-v2-beta")
+    })
+
+    it("trims leading and trailing hyphens", async () => {
+      const { slugifyProjectName } = await import("../api/project-store.js")
+      expect(slugifyProjectName("  -- hello -- ")).toBe("hello")
+    })
+
+    it("handles names with only special characters", async () => {
+      const { slugifyProjectName } = await import("../api/project-store.js")
+      expect(slugifyProjectName("!!! ???")).toBe("")
+    })
+  })
+
+  describe("getProjectDir", () => {
+    it("returns path under projects directory", async () => {
+      const { getProjectDir } = await import("../api/project-store.js")
+      const dir = getProjectDir("my-project")
+      expect(dir).toMatch(/projects\/my-project$/)
+    })
+  })
+
+  describe("ensureProjectDir", () => {
+    it("creates directory and files when they do not exist", async () => {
+      mockExistsSync.mockReturnValue(false)
+      const { ensureProjectDir } = await import("../api/project-store.js")
+
+      const result = ensureProjectDir("Test Project")
+
+      expect(result.slug).toBe("test-project")
+      expect(result.dirPath).toMatch(/projects\/test-project$/)
+      expect(mockMkdirSync).toHaveBeenCalledWith(result.dirPath, {
+        recursive: true,
+        mode: 0o700,
+      })
+      // Should create README.md and CONTEXT.md (2 writes + 2 renames)
+      expect(mockWriteFileSync).toHaveBeenCalledTimes(2)
+      expect(mockRenameSync).toHaveBeenCalledTimes(2)
+    })
+
+    it("skips creation when directory already exists", async () => {
+      mockExistsSync.mockReturnValue(true)
+      const { ensureProjectDir } = await import("../api/project-store.js")
+
+      const result = ensureProjectDir("Existing Project")
+
+      expect(result.slug).toBe("existing-project")
+      expect(mockMkdirSync).not.toHaveBeenCalled()
+      expect(mockWriteFileSync).not.toHaveBeenCalled()
+    })
+
+    it("includes project URL in README when provided", async () => {
+      mockExistsSync.mockReturnValue(false)
+      const { ensureProjectDir } = await import("../api/project-store.js")
+
+      ensureProjectDir("My Proj", {
+        projectUrl: "https://linear.app/test/project/my-proj",
+      })
+
+      const readmeCall = mockWriteFileSync.mock.calls.find(([path]) => (path as string).endsWith("README.md.tmp"))
+      expect(readmeCall).toBeDefined()
+      expect(readmeCall?.[1]).toContain("https://linear.app/test/project/my-proj")
+    })
+
+    it("omits project URL in README when not provided", async () => {
+      mockExistsSync.mockReturnValue(false)
+      const { ensureProjectDir } = await import("../api/project-store.js")
+
+      ensureProjectDir("My Proj")
+
+      const readmeCall = mockWriteFileSync.mock.calls.find(([path]) => (path as string).endsWith("README.md.tmp"))
+      expect(readmeCall).toBeDefined()
+      expect(readmeCall?.[1]).not.toContain("Linear:")
+    })
+
+    it("logs creation when logger is provided", async () => {
+      mockExistsSync.mockReturnValue(false)
+      const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+      const { ensureProjectDir } = await import("../api/project-store.js")
+
+      ensureProjectDir("Logged Project", { logger })
+
+      expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("created project directory"))
+      expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("initialized project files"))
+    })
+
+    it("writes files atomically (tmp + rename)", async () => {
+      mockExistsSync.mockReturnValue(false)
+      const { ensureProjectDir } = await import("../api/project-store.js")
+
+      ensureProjectDir("Atomic Test")
+
+      for (const [tmpPath, , opts] of mockWriteFileSync.mock.calls) {
+        expect(tmpPath).toMatch(/\.tmp$/)
+        expect((opts as { mode: number }).mode).toBe(0o600)
+      }
+      // Each write should be followed by a rename
+      expect(mockRenameSync).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe("resolveProjectInfo", () => {
+    it("returns null when project is null", async () => {
+      mockExistsSync.mockReturnValue(true)
+      const { resolveProjectInfo } = await import("../api/project-store.js")
+
+      expect(resolveProjectInfo(null)).toBeNull()
+    })
+
+    it("returns null when project is undefined", async () => {
+      mockExistsSync.mockReturnValue(true)
+      const { resolveProjectInfo } = await import("../api/project-store.js")
+
+      expect(resolveProjectInfo(undefined)).toBeNull()
+    })
+
+    it("returns null when project has no id", async () => {
+      mockExistsSync.mockReturnValue(true)
+      const { resolveProjectInfo } = await import("../api/project-store.js")
+
+      expect(resolveProjectInfo({ id: "", name: "Test" })).toBeNull()
+    })
+
+    it("returns null when project has no name", async () => {
+      mockExistsSync.mockReturnValue(true)
+      const { resolveProjectInfo } = await import("../api/project-store.js")
+
+      expect(resolveProjectInfo({ id: "proj-1", name: "" })).toBeNull()
+    })
+
+    it("returns project info with all fields when project is valid", async () => {
+      mockExistsSync.mockReturnValue(true)
+      const { resolveProjectInfo } = await import("../api/project-store.js")
+
+      const result = resolveProjectInfo({ id: "proj-1", name: "My Project" })
+
+      expect(result).toEqual({
+        id: "proj-1",
+        name: "My Project",
+        slug: "my-project",
+        dirPath: expect.stringMatching(/projects\/my-project$/),
+      })
+    })
+  })
+})

--- a/src/__test__/webhook-handler.test.ts
+++ b/src/__test__/webhook-handler.test.ts
@@ -14,11 +14,18 @@ const mockLogger = {
 
 const mockDispatchInboundReplyWithBase = vi.fn().mockResolvedValue(undefined)
 
+const mockExistsSync = vi.fn().mockReturnValue(true)
+const mockMkdirSync = vi.fn()
+const mockRenameSync = vi.fn()
+
 vi.mock("node:fs", () => ({
+  existsSync: mockExistsSync,
+  mkdirSync: mockMkdirSync,
   readFileSync: vi.fn(() => {
     throw new Error("no file")
   }),
   writeFileSync: vi.fn(),
+  renameSync: mockRenameSync,
 }))
 
 vi.mock("openclaw/plugin-sdk", () => ({
@@ -185,6 +192,7 @@ describe("handleWebhook", () => {
     })
     mockRuntime.channel.session.resolveStorePath.mockReturnValue("/tmp/store/agent-main")
     mockRuntime.channel.reply.finalizeInboundContext.mockImplementation((ctx: any) => ctx)
+    mockExistsSync.mockReturnValue(true)
   })
 
   afterEach(() => {
@@ -1060,6 +1068,121 @@ describe("handleWebhook", () => {
       expect(mockDispatchInboundReplyWithBase).toHaveBeenCalled()
       expect(mockLinearApi.getIssueDetails).toHaveBeenCalledWith(commentIssueId)
       expect(mockLinearApi.updateIssueState).toHaveBeenCalledWith(commentIssueId, "In Progress")
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  describe("project context injection", () => {
+    // -----------------------------------------------------------------------
+
+    it("includes project context in session created when issue has a project", async () => {
+      const { handleWebhook } = await import("../webhook-handler.js")
+      const api = makeApi({ accessToken: "lin_test_token" })
+
+      mockLinearApi.getIssueDetails.mockReset()
+      mockLinearApi.getIssueDetails.mockResolvedValue({
+        id: "issue-1",
+        identifier: "ENG-42",
+        title: "Test",
+        description: null,
+        url: "https://linear.app/test/ENG-42",
+        project: { id: "proj-1", name: "My Project" },
+      })
+
+      const payload = uniqueCreated()
+      const { req, res } = makeSignedReq(payload, SECRET)
+
+      await handleWebhook(api, req, res)
+
+      expect(res.writeHead).toHaveBeenCalledWith(200, expect.any(Object))
+      const dispatchCall = mockDispatchInboundReplyWithBase.mock.calls[0][0]
+      expect(dispatchCall.ctxPayload.Body).toContain("Project Memory")
+      expect(dispatchCall.ctxPayload.Body).toContain("My Project")
+      expect(dispatchCall.ctxPayload.Body).toContain("CONTEXT.md")
+      expect(dispatchCall.ctxPayload.Body).toContain("README.md")
+    })
+
+    it("omits project context when issue has no project", async () => {
+      const { handleWebhook } = await import("../webhook-handler.js")
+      const api = makeApi({ accessToken: "lin_test_token" })
+
+      // Default mock has no project field — project should be omitted
+      const payload = uniqueCreated()
+      const { req, res } = makeSignedReq(payload, SECRET)
+
+      await handleWebhook(api, req, res)
+
+      const dispatchCall = mockDispatchInboundReplyWithBase.mock.calls[0][0]
+      expect(dispatchCall.ctxPayload.Body).not.toContain("Project Memory")
+    })
+
+    it("omits project context when projectMemoryEnabled is false", async () => {
+      const { handleWebhook } = await import("../webhook-handler.js")
+      const api = makeApi({ accessToken: "lin_test_token", projectMemoryEnabled: false })
+
+      const payload = uniqueCreated()
+      const { req, res } = makeSignedReq(payload, SECRET)
+
+      await handleWebhook(api, req, res)
+
+      const dispatchCall = mockDispatchInboundReplyWithBase.mock.calls[0][0]
+      expect(dispatchCall.ctxPayload.Body).not.toContain("Project Memory")
+      // getIssueDetails should not be called for project context when disabled
+      expect(mockLinearApi.getIssueDetails).not.toHaveBeenCalled()
+    })
+
+    it("includes project context in comment create fallback", async () => {
+      const { handleWebhook } = await import("../webhook-handler.js")
+      const api = makeApi({ accessToken: "lin_test_token" })
+
+      const commentIssueId = `issue-proj-${uid}`
+      mockLinearApi.getIssueDetails.mockReset()
+      mockLinearApi.getIssueDetails.mockResolvedValue({
+        id: commentIssueId,
+        identifier: "ENG-99",
+        title: "Comment Project Test",
+        description: "Test project in comment fallback",
+        url: "https://linear.app/test/ENG-99",
+        project: { id: "proj-2", name: "Backend API" },
+      })
+
+      const payload = {
+        type: "Comment",
+        action: "create",
+        createdAt: `2026-04-01T20:00:${String(uid++).padStart(2, "0")}.000Z`,
+        data: {
+          id: `comment-proj-${uid}`,
+          body: "@Linus check this project",
+          issue: { id: commentIssueId },
+        },
+      }
+      const { req, res } = makeSignedReq(payload, SECRET)
+
+      await handleWebhook(api, req, res)
+
+      expect(res.writeHead).toHaveBeenCalledWith(200, expect.any(Object))
+      const dispatchCall = mockDispatchInboundReplyWithBase.mock.calls[0][0]
+      expect(dispatchCall.ctxPayload.Body).toContain("Project Memory")
+      expect(dispatchCall.ctxPayload.Body).toContain("Backend API")
+    })
+
+    it("gracefully handles getIssueDetails failure for project context", async () => {
+      const { handleWebhook } = await import("../webhook-handler.js")
+      const api = makeApi({ accessToken: "lin_test_token" })
+
+      mockLinearApi.getIssueDetails.mockReset()
+      mockLinearApi.getIssueDetails.mockRejectedValue(new Error("network error"))
+
+      const payload = uniqueCreated()
+      const { req, res } = makeSignedReq(payload, SECRET)
+
+      await handleWebhook(api, req, res)
+
+      // Should still succeed — project context is best-effort
+      expect(res.writeHead).toHaveBeenCalledWith(200, expect.any(Object))
+      expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining("failed to resolve project context"))
+      const dispatchCall = mockDispatchInboundReplyWithBase.mock.calls[0][0]
+      expect(dispatchCall.ctxPayload.Body).not.toContain("Project Memory")
     })
   })
 

--- a/src/__test__/webhook-handler.test.ts
+++ b/src/__test__/webhook-handler.test.ts
@@ -1098,9 +1098,9 @@ describe("handleWebhook", () => {
 
       expect(res.writeHead).toHaveBeenCalledWith(200, expect.any(Object))
       const dispatchCall = mockDispatchInboundReplyWithBase.mock.calls[0][0]
-      expect(dispatchCall.ctxPayload.Body).toContain("Project memory")
+      expect(dispatchCall.ctxPayload.Body).toContain("Project Memory")
       expect(dispatchCall.ctxPayload.Body).toContain("AGENTS.md")
-      expect(dispatchCall.ctxPayload.Body).toContain("follow its rules strictly")
+      expect(dispatchCall.ctxPayload.Body).toContain("read these files to restore context")
     })
 
     it("omits project context when issue has no project", async () => {
@@ -1114,7 +1114,7 @@ describe("handleWebhook", () => {
       await handleWebhook(api, req, res)
 
       const dispatchCall = mockDispatchInboundReplyWithBase.mock.calls[0][0]
-      expect(dispatchCall.ctxPayload.Body).not.toContain("Project memory")
+      expect(dispatchCall.ctxPayload.Body).not.toContain("Project Memory")
     })
 
     it("omits project context when projectMemoryEnabled is false", async () => {
@@ -1127,7 +1127,7 @@ describe("handleWebhook", () => {
       await handleWebhook(api, req, res)
 
       const dispatchCall = mockDispatchInboundReplyWithBase.mock.calls[0][0]
-      expect(dispatchCall.ctxPayload.Body).not.toContain("Project memory")
+      expect(dispatchCall.ctxPayload.Body).not.toContain("Project Memory")
       // getIssueDetails should not be called for project context when disabled
       expect(mockLinearApi.getIssueDetails).not.toHaveBeenCalled()
     })
@@ -1154,7 +1154,7 @@ describe("handleWebhook", () => {
 
       expect(res.writeHead).toHaveBeenCalledWith(200, expect.any(Object))
       const dispatchCall = mockDispatchInboundReplyWithBase.mock.calls[0][0]
-      expect(dispatchCall.ctxPayload.Body).toContain("Project memory")
+      expect(dispatchCall.ctxPayload.Body).toContain("Project Memory")
       expect(dispatchCall.ctxPayload.Body).toContain("AGENTS.md")
     })
 
@@ -1168,7 +1168,7 @@ describe("handleWebhook", () => {
       await handleWebhook(api, req, res)
 
       const dispatchCall = mockDispatchInboundReplyWithBase.mock.calls[0][0]
-      expect(dispatchCall.ctxPayload.Body).not.toContain("Project memory")
+      expect(dispatchCall.ctxPayload.Body).not.toContain("Project Memory")
     })
 
     it("gracefully handles getIssueDetails failure for project context in prompted", async () => {
@@ -1219,7 +1219,7 @@ describe("handleWebhook", () => {
 
       expect(res.writeHead).toHaveBeenCalledWith(200, expect.any(Object))
       const dispatchCall = mockDispatchInboundReplyWithBase.mock.calls[0][0]
-      expect(dispatchCall.ctxPayload.Body).toContain("Project memory")
+      expect(dispatchCall.ctxPayload.Body).toContain("Project Memory")
     })
 
     it("gracefully handles getIssueDetails failure for project context", async () => {
@@ -1238,7 +1238,7 @@ describe("handleWebhook", () => {
       expect(res.writeHead).toHaveBeenCalledWith(200, expect.any(Object))
       expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining("failed to resolve project context"))
       const dispatchCall = mockDispatchInboundReplyWithBase.mock.calls[0][0]
-      expect(dispatchCall.ctxPayload.Body).not.toContain("Project memory")
+      expect(dispatchCall.ctxPayload.Body).not.toContain("Project Memory")
     })
 
     it("includes project update instructions in completion loop prompt", async () => {

--- a/src/__test__/webhook-handler.test.ts
+++ b/src/__test__/webhook-handler.test.ts
@@ -183,6 +183,7 @@ describe("handleWebhook", () => {
       title: "Test",
       description: null,
       url: "https://linear.app/test/ENG-42",
+      comments: { nodes: [] },
     })
     mockRuntime.channel.routing.resolveAgentRoute.mockReturnValue({
       agentId: "agent-main",
@@ -1087,6 +1088,7 @@ describe("handleWebhook", () => {
         description: null,
         url: "https://linear.app/test/ENG-42",
         project: { id: "proj-1", name: "My Project" },
+        comments: { nodes: [] },
       })
 
       const payload = uniqueCreated()
@@ -1130,6 +1132,61 @@ describe("handleWebhook", () => {
       expect(mockLinearApi.getIssueDetails).not.toHaveBeenCalled()
     })
 
+    it("includes project context in session prompted when issue has a project", async () => {
+      const { handleWebhook } = await import("../webhook-handler.js")
+      const api = makeApi({ accessToken: "lin_test_token" })
+
+      mockLinearApi.getIssueDetails.mockReset()
+      mockLinearApi.getIssueDetails.mockResolvedValue({
+        id: "issue-prompted-proj",
+        identifier: "ENG-50",
+        title: "Prompted Project Test",
+        description: null,
+        url: "https://linear.app/test/ENG-50",
+        project: { id: "proj-3", name: "Frontend" },
+        comments: { nodes: [] },
+      })
+
+      const payload = uniquePrompted()
+      const { req, res } = makeSignedReq(payload, SECRET)
+
+      await handleWebhook(api, req, res)
+
+      expect(res.writeHead).toHaveBeenCalledWith(200, expect.any(Object))
+      const dispatchCall = mockDispatchInboundReplyWithBase.mock.calls[0][0]
+      expect(dispatchCall.ctxPayload.Body).toContain("Project memory")
+      expect(dispatchCall.ctxPayload.Body).toContain("AGENTS.md")
+    })
+
+    it("omits project context in session prompted when projectMemoryEnabled is false", async () => {
+      const { handleWebhook } = await import("../webhook-handler.js")
+      const api = makeApi({ accessToken: "lin_test_token", projectMemoryEnabled: false })
+
+      const payload = uniquePrompted()
+      const { req, res } = makeSignedReq(payload, SECRET)
+
+      await handleWebhook(api, req, res)
+
+      const dispatchCall = mockDispatchInboundReplyWithBase.mock.calls[0][0]
+      expect(dispatchCall.ctxPayload.Body).not.toContain("Project memory")
+    })
+
+    it("gracefully handles getIssueDetails failure for project context in prompted", async () => {
+      const { handleWebhook } = await import("../webhook-handler.js")
+      const api = makeApi({ accessToken: "lin_test_token" })
+
+      mockLinearApi.getIssueDetails.mockReset()
+      mockLinearApi.getIssueDetails.mockRejectedValue(new Error("network error"))
+
+      const payload = uniquePrompted()
+      const { req, res } = makeSignedReq(payload, SECRET)
+
+      await handleWebhook(api, req, res)
+
+      expect(res.writeHead).toHaveBeenCalledWith(200, expect.any(Object))
+      expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining("failed to resolve project context"))
+    })
+
     it("includes project context in comment create fallback", async () => {
       const { handleWebhook } = await import("../webhook-handler.js")
       const api = makeApi({ accessToken: "lin_test_token" })
@@ -1143,6 +1200,7 @@ describe("handleWebhook", () => {
         description: "Test project in comment fallback",
         url: "https://linear.app/test/ENG-99",
         project: { id: "proj-2", name: "Backend API" },
+        comments: { nodes: [] },
       })
 
       const payload = {
@@ -1201,6 +1259,7 @@ describe("handleWebhook", () => {
         description: null,
         url: "https://linear.app/test/ENG-42",
         project: { id: "proj-1", name: "My Project" },
+        comments: { nodes: [] },
       })
 
       mockDispatchInboundReplyWithBase.mockClear()

--- a/src/__test__/webhook-handler.test.ts
+++ b/src/__test__/webhook-handler.test.ts
@@ -1210,8 +1210,8 @@ describe("handleWebhook", () => {
       expect(mockDispatchInboundReplyWithBase).toHaveBeenCalledTimes(1)
       const dispatchCall = mockDispatchInboundReplyWithBase.mock.calls[0][0]
       expect(dispatchCall.ctxPayload.Body).toContain("Context.md")
-      expect(dispatchCall.ctxPayload.Body).toContain("issues/ENG-42.md")
-      expect(dispatchCall.ctxPayload.Body).toContain("Linear API")
+      expect(dispatchCall.ctxPayload.Body).not.toContain("issues/")
+      expect(dispatchCall.ctxPayload.Body).not.toContain("Linear API")
     })
 
     it("omits project update instructions when projectMemoryEnabled is false", async () => {

--- a/src/__test__/webhook-handler.test.ts
+++ b/src/__test__/webhook-handler.test.ts
@@ -1096,10 +1096,8 @@ describe("handleWebhook", () => {
 
       expect(res.writeHead).toHaveBeenCalledWith(200, expect.any(Object))
       const dispatchCall = mockDispatchInboundReplyWithBase.mock.calls[0][0]
-      expect(dispatchCall.ctxPayload.Body).toContain("Project Memory")
-      expect(dispatchCall.ctxPayload.Body).toContain("My Project")
-      expect(dispatchCall.ctxPayload.Body).toContain("CONTEXT.md")
-      expect(dispatchCall.ctxPayload.Body).toContain("README.md")
+      expect(dispatchCall.ctxPayload.Body).toContain("Project memory")
+      expect(dispatchCall.ctxPayload.Body).toContain("follow its rules")
     })
 
     it("omits project context when issue has no project", async () => {
@@ -1113,7 +1111,7 @@ describe("handleWebhook", () => {
       await handleWebhook(api, req, res)
 
       const dispatchCall = mockDispatchInboundReplyWithBase.mock.calls[0][0]
-      expect(dispatchCall.ctxPayload.Body).not.toContain("Project Memory")
+      expect(dispatchCall.ctxPayload.Body).not.toContain("Project memory")
     })
 
     it("omits project context when projectMemoryEnabled is false", async () => {
@@ -1126,7 +1124,7 @@ describe("handleWebhook", () => {
       await handleWebhook(api, req, res)
 
       const dispatchCall = mockDispatchInboundReplyWithBase.mock.calls[0][0]
-      expect(dispatchCall.ctxPayload.Body).not.toContain("Project Memory")
+      expect(dispatchCall.ctxPayload.Body).not.toContain("Project memory")
       // getIssueDetails should not be called for project context when disabled
       expect(mockLinearApi.getIssueDetails).not.toHaveBeenCalled()
     })
@@ -1162,8 +1160,7 @@ describe("handleWebhook", () => {
 
       expect(res.writeHead).toHaveBeenCalledWith(200, expect.any(Object))
       const dispatchCall = mockDispatchInboundReplyWithBase.mock.calls[0][0]
-      expect(dispatchCall.ctxPayload.Body).toContain("Project Memory")
-      expect(dispatchCall.ctxPayload.Body).toContain("Backend API")
+      expect(dispatchCall.ctxPayload.Body).toContain("Project memory")
     })
 
     it("gracefully handles getIssueDetails failure for project context", async () => {
@@ -1182,7 +1179,7 @@ describe("handleWebhook", () => {
       expect(res.writeHead).toHaveBeenCalledWith(200, expect.any(Object))
       expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining("failed to resolve project context"))
       const dispatchCall = mockDispatchInboundReplyWithBase.mock.calls[0][0]
-      expect(dispatchCall.ctxPayload.Body).not.toContain("Project Memory")
+      expect(dispatchCall.ctxPayload.Body).not.toContain("Project memory")
     })
   })
 

--- a/src/__test__/webhook-handler.test.ts
+++ b/src/__test__/webhook-handler.test.ts
@@ -1097,7 +1097,8 @@ describe("handleWebhook", () => {
       expect(res.writeHead).toHaveBeenCalledWith(200, expect.any(Object))
       const dispatchCall = mockDispatchInboundReplyWithBase.mock.calls[0][0]
       expect(dispatchCall.ctxPayload.Body).toContain("Project memory")
-      expect(dispatchCall.ctxPayload.Body).toContain("follow its rules")
+      expect(dispatchCall.ctxPayload.Body).toContain("AGENTS.md")
+      expect(dispatchCall.ctxPayload.Body).toContain("follow its rules strictly")
     })
 
     it("omits project context when issue has no project", async () => {
@@ -1180,6 +1181,54 @@ describe("handleWebhook", () => {
       expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining("failed to resolve project context"))
       const dispatchCall = mockDispatchInboundReplyWithBase.mock.calls[0][0]
       expect(dispatchCall.ctxPayload.Body).not.toContain("Project memory")
+    })
+
+    it("includes project update instructions in completion loop prompt", async () => {
+      const { handleWebhook, dispatchCompletionPrompt } = await import("../webhook-handler.js")
+      const api = makeApi({ accessToken: "lin_test_token" })
+
+      // First, handle a webhook to capture dispatch context
+      const payload = uniqueCreated()
+      const { req, res } = makeSignedReq(payload, SECRET)
+      await handleWebhook(api, req, res)
+
+      // Set up getIssueDetails to return project info for completion loop
+      mockLinearApi.getIssueDetails.mockReset()
+      mockLinearApi.getIssueDetails.mockResolvedValue({
+        id: payload.agentSession.issue.id,
+        identifier: "ENG-42",
+        title: "Test",
+        description: null,
+        url: "https://linear.app/test/ENG-42",
+        project: { id: "proj-1", name: "My Project" },
+      })
+
+      mockDispatchInboundReplyWithBase.mockClear()
+
+      await dispatchCompletionPrompt(payload.agentSession.issue.id, "ENG-42", "check status")
+
+      expect(mockDispatchInboundReplyWithBase).toHaveBeenCalledTimes(1)
+      const dispatchCall = mockDispatchInboundReplyWithBase.mock.calls[0][0]
+      expect(dispatchCall.ctxPayload.Body).toContain("Context.md")
+      expect(dispatchCall.ctxPayload.Body).toContain("issues/ENG-42.md")
+      expect(dispatchCall.ctxPayload.Body).toContain("Linear API")
+    })
+
+    it("omits project update instructions when projectMemoryEnabled is false", async () => {
+      const { handleWebhook, dispatchCompletionPrompt } = await import("../webhook-handler.js")
+      const api = makeApi({ accessToken: "lin_test_token", projectMemoryEnabled: false })
+
+      const payload = uniqueCreated()
+      const { req, res } = makeSignedReq(payload, SECRET)
+      await handleWebhook(api, req, res)
+
+      mockDispatchInboundReplyWithBase.mockClear()
+
+      await dispatchCompletionPrompt(payload.agentSession.issue.id, "ENG-42", "check status")
+
+      expect(mockDispatchInboundReplyWithBase).toHaveBeenCalledTimes(1)
+      const dispatchCall = mockDispatchInboundReplyWithBase.mock.calls[0][0]
+      expect(dispatchCall.ctxPayload.Body).not.toContain("Context.md")
     })
   })
 

--- a/src/api/project-store.ts
+++ b/src/api/project-store.ts
@@ -7,8 +7,8 @@
  * Each project directory contains:
  * - AGENTS.md   — project rules and instructions (agent must read first)
  * - README.md   — project purpose and background
- * - Context.md  — refined/extracted context for session continuity
- * - issues/     — per-issue conversation records
+ * - Context.md  — refined/extracted context for session continuity (written by agent)
+ * - issues/     — per-issue conversation records (auto-managed by plugin)
  *
  * Follows the same atomic write-then-rename pattern as oauth-store.ts.
  */
@@ -62,10 +62,10 @@ export function ensureProjectDir(
     // Initialize README.md (project purpose and background)
     atomicWrite(join(dirPath, "README.md"), buildReadme(projectName, opts?.projectUrl))
 
-    // Initialize Context.md (refined/extracted context)
+    // Initialize Context.md (refined/extracted context — written by agent)
     atomicWrite(join(dirPath, "Context.md"), buildContext(projectName))
 
-    // Create issues/ directory
+    // Create issues/ directory (auto-managed by plugin)
     mkdirSync(join(dirPath, "issues"), { mode: 0o700 })
 
     opts?.logger?.info(`Linear Light: initialized project files for "${projectName}"`)
@@ -88,6 +88,45 @@ export function resolveProjectInfo(
   return { id: project.id, name: project.name, slug, dirPath }
 }
 
+/** Shape of a single comment from Linear API. */
+interface IssueComment {
+  user: { name: string | null } | null
+  body: string
+  createdAt: string
+}
+
+/**
+ * Sync an issue's conversation to the project's issues/ directory.
+ * Pulls comments from Linear API and writes them to `issues/<identifier>.md`.
+ * Called automatically by the plugin — the agent should NOT write to issues/ manually.
+ */
+export function syncIssueConversation(
+  projectDirPath: string,
+  issueIdentifier: string,
+  comments: IssueComment[],
+  opts?: { logger?: Logger },
+): void {
+  const issuesDir = join(projectDirPath, "issues")
+  if (!existsSync(issuesDir)) {
+    mkdirSync(issuesDir, { recursive: true, mode: 0o700 })
+  }
+
+  const lines = [`# ${issueIdentifier} — Conversation`, ""]
+
+  for (const comment of comments) {
+    const author = comment.user?.name ?? "Unknown"
+    const time = comment.createdAt ? new Date(comment.createdAt).toISOString().replace("T", " ").split(".")[0] : ""
+    lines.push(`## ${author}${time ? ` (${time})` : ""}`, "", comment.body, "")
+  }
+
+  if (comments.length === 0) {
+    lines.push("_No comments yet._", "")
+  }
+
+  atomicWrite(join(issuesDir, `${issueIdentifier}.md`), lines.join("\n"))
+  opts?.logger?.info(`Linear Light: synced ${comments.length} comments for ${issueIdentifier}`)
+}
+
 /**
  * Build AGENTS.md — the project rules and instructions file.
  * The agent must read this file first; it defines the conventions for all other files.
@@ -101,15 +140,15 @@ function buildAgentsMd(projectName: string): string {
     "## Project Directory Structure",
     "",
     "- `README.md` — Project purpose and background.",
-    "- `Context.md` — Refined/extracted context: technical state, key findings, architecture decisions. Update this as work progresses.",
-    "- `issues/` — Per-issue conversation records. Each issue gets `issues/<Identifier>.md`. Pull content from Linear API (comments), do not write manually.",
+    "- `Context.md` — Refined/extracted context: technical state, key findings, architecture decisions. **You should update this file** as work progresses.",
+    "- `issues/` — Per-issue conversation records, auto-managed by the plugin. **Do not write to this directory manually.**",
     "- `AGENTS.md` — This file. Contains project rules and user instructions.",
     "",
     "## Instructions",
     "",
     "- Always read `Context.md` before starting work to understand current state.",
     "- Update `Context.md` when making significant progress or discoveries.",
-    "- For issue conversation history, use the Linear API to pull comments into `issues/<Identifier>.md`.",
+    "- Do not modify files in `issues/` — the plugin syncs them automatically from Linear.",
     "",
   ].join("\n")
 }

--- a/src/api/project-store.ts
+++ b/src/api/project-store.ts
@@ -1,8 +1,8 @@
 /**
  * Project-based memory persistence store.
  *
- * Creates and manages per-project directories under
- * ~/.openclaw/plugins/linear-light/projects/<slug>/
+ * Creates and manages per-project directories under the configured base path
+ * (default: ~/clawd/projects/<slug>/).
  *
  * Each project directory contains:
  * - AGENTS.md   — project rules and instructions (agent must read first)
@@ -13,13 +13,41 @@
  * Follows the same atomic write-then-rename pattern as oauth-store.ts.
  */
 
-import { existsSync, mkdirSync, renameSync, writeFileSync } from "node:fs"
+import { execSync } from "node:child_process"
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs"
 import { homedir } from "node:os"
-import { dirname, join } from "node:path"
+import { dirname, join, resolve } from "node:path"
 
 import type { Logger } from "./linear-api.js"
 
-const PROJECTS_DIR = join(homedir(), ".openclaw", "plugins", "linear-light", "projects")
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+export interface ProjectStoreConfig {
+  enabled: boolean
+  basePath: string // e.g., "/Users/jingyi/clawd/projects"
+  autoGit: boolean // auto git init / commit / push on dir creation
+}
+
+let _config: ProjectStoreConfig = {
+  enabled: true,
+  basePath: resolve(homedir(), "clawd", "projects"),
+  autoGit: true,
+}
+
+export function setProjectStoreConfig(pluginConfig: Record<string, unknown> | undefined): void {
+  const cfg = pluginConfig ?? {}
+  _config = {
+    enabled: cfg.projectMemoryEnabled !== false,
+    basePath: (cfg.projectMemoryBasePath as string) || resolve(homedir(), "clawd", "projects"),
+    autoGit: cfg.projectMemoryAutoGit !== false,
+  }
+}
+
+export function getProjectStoreConfig(): ProjectStoreConfig {
+  return _config
+}
 
 /**
  * Convert a Linear project name and id to a unique, URL-safe directory slug.
@@ -53,8 +81,8 @@ function shortHash(str: string): string {
 /**
  * Get the directory path for a project slug.
  */
-export function getProjectDir(slug: string): string {
-  return join(PROJECTS_DIR, slug)
+export function getProjectDir(slug: string, basePath?: string): string {
+  return join(basePath ?? _config.basePath, slug)
 }
 
 /**
@@ -65,7 +93,7 @@ export function getProjectDir(slug: string): string {
 export function ensureProjectDir(
   projectName: string,
   opts?: { logger?: Logger; projectUrl?: string; projectId?: string },
-): { dirPath: string; slug: string } {
+): { dirPath: string; slug: string; created: boolean } {
   const slug = slugifyProjectName(projectName, opts?.projectId)
   const dirPath = getProjectDir(slug)
 
@@ -86,9 +114,16 @@ export function ensureProjectDir(
     mkdirSync(join(dirPath, "issues"), { mode: 0o700 })
 
     opts?.logger?.info(`Linear Light: initialized project files for "${projectName}"`)
+
+    // Auto-init git repo if configured
+    if (_config.autoGit) {
+      initGitRepo(dirPath, opts?.logger)
+    }
+
+    return { dirPath, slug, created: true }
   }
 
-  return { dirPath, slug }
+  return { dirPath, slug, created: false }
 }
 
 /**
@@ -211,6 +246,79 @@ function buildContext(projectName: string): string {
     "",
     "",
   ].join("\n")
+}
+
+/**
+ * Initialize a git repo in the project directory if it doesn't exist.
+ */
+export function initGitRepo(dirPath: string, logger?: Logger): boolean {
+  const gitDir = join(dirPath, ".git")
+  if (existsSync(gitDir)) return false
+
+  try {
+    execSync("git init", { cwd: dirPath, stdio: "pipe" })
+    // Create initial commit
+    execSync("git add -A && git commit -m 'init: project directory'", {
+      cwd: dirPath,
+      stdio: "pipe",
+      timeout: 30_000,
+    })
+    logger?.info(`Linear Light: initialized git repo in ${dirPath}`)
+    return true
+  } catch (err) {
+    logger?.warn(`Linear Light: git init failed for ${dirPath}: ${err}`)
+    return false
+  }
+}
+
+/**
+ * Save/append content to a file in the project directory and optionally git commit + push.
+ * Used by the project_memory_save tool.
+ */
+export function saveProjectFile(
+  dirPath: string,
+  filename: string,
+  content: string,
+  mode: "replace" | "append" = "replace",
+  logger?: Logger,
+): { ok: boolean; message: string } {
+  try {
+    if (!existsSync(dirPath)) {
+      mkdirSync(dirPath, { recursive: true })
+    }
+
+    const filePath = join(dirPath, filename)
+    if (mode === "append" && existsSync(filePath)) {
+      const existing = readFileSync(filePath, "utf-8")
+      writeFileSync(filePath, `${existing}\n${content}`, "utf-8")
+    } else {
+      writeFileSync(filePath, content, "utf-8")
+    }
+
+    // Git commit + push if configured
+    let gitMsg = ""
+    if (_config.autoGit) {
+      try {
+        if (!existsSync(join(dirPath, ".git"))) {
+          initGitRepo(dirPath, logger)
+        }
+        const commitMsg = `update ${filename}`
+        execSync(`git add -A && git commit -m ${JSON.stringify(commitMsg)} && git push`, {
+          cwd: dirPath,
+          stdio: "pipe",
+          timeout: 30_000,
+        })
+        gitMsg = " (committed + pushed)"
+      } catch (err) {
+        gitMsg = ` (git failed: ${err instanceof Error ? err.message : String(err)})`
+        logger?.warn(`Linear Light: git commit failed: ${err}`)
+      }
+    }
+
+    return { ok: true, message: `Saved ${filename} to ${dirPath}${gitMsg}` }
+  } catch (err) {
+    return { ok: false, message: `Failed: ${err instanceof Error ? err.message : String(err)}` }
+  }
 }
 
 /**

--- a/src/api/project-store.ts
+++ b/src/api/project-store.ts
@@ -1,0 +1,136 @@
+/**
+ * Project-based memory persistence store.
+ *
+ * Creates and manages per-project directories under
+ * ~/.openclaw/plugins/linear-light/projects/<slug>/
+ *
+ * Each project directory contains:
+ * - README.md  — project overview with issue inventory
+ * - CONTEXT.md — session continuity context for the agent
+ *
+ * Follows the same atomic write-then-rename pattern as oauth-store.ts.
+ */
+
+import { existsSync, mkdirSync, renameSync, writeFileSync } from "node:fs"
+import { homedir } from "node:os"
+import { join } from "node:path"
+
+import type { Logger } from "./linear-api.js"
+
+const PROJECTS_DIR = join(homedir(), ".openclaw", "plugins", "linear-light", "projects")
+
+/**
+ * Convert a Linear project name to a URL-safe directory slug.
+ * e.g. "EWL" → "ewl", "My Project" → "my-project", "API v2" → "api-v2"
+ */
+export function slugifyProjectName(name: string): string {
+  return name
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+}
+
+/**
+ * Get the directory path for a project slug.
+ */
+export function getProjectDir(slug: string): string {
+  return join(PROJECTS_DIR, slug)
+}
+
+/**
+ * Ensure the project directory and its base files exist.
+ * Idempotent — safe to call multiple times.
+ * Returns the directory path.
+ */
+export function ensureProjectDir(
+  projectName: string,
+  opts?: { logger?: Logger; projectUrl?: string },
+): { dirPath: string; slug: string } {
+  const slug = slugifyProjectName(projectName)
+  const dirPath = getProjectDir(slug)
+
+  if (!existsSync(dirPath)) {
+    mkdirSync(dirPath, { recursive: true, mode: 0o700 })
+    opts?.logger?.info(`Linear Light: created project directory ${dirPath}`)
+
+    // Initialize README.md
+    const readme = buildReadme(projectName, opts?.projectUrl)
+    atomicWrite(join(dirPath, "README.md"), readme)
+
+    // Initialize CONTEXT.md
+    const context = buildContext(projectName)
+    atomicWrite(join(dirPath, "CONTEXT.md"), context)
+
+    opts?.logger?.info(`Linear Light: initialized project files for "${projectName}"`)
+  }
+
+  return { dirPath, slug }
+}
+
+/**
+ * Resolve project info from an issue's project field.
+ * Returns null if the issue has no project.
+ */
+export function resolveProjectInfo(
+  project: { id: string; name: string } | null | undefined,
+  opts?: { logger?: Logger; projectUrl?: string },
+): { dirPath: string; slug: string; id: string; name: string } | null {
+  if (!(project?.id && project?.name)) return null
+
+  const { dirPath, slug } = ensureProjectDir(project.name, opts)
+  return { id: project.id, name: project.name, slug, dirPath }
+}
+
+/**
+ * Build the default README.md content for a new project.
+ */
+function buildReadme(projectName: string, projectUrl?: string): string {
+  const lines = [
+    `# ${projectName}`,
+    "",
+    projectUrl ? `Linear: ${projectUrl}` : "",
+    "",
+    "## Issues",
+    "",
+    "| Identifier | Title | Status | Priority |",
+    "| --- | --- | --- | --- |",
+    "",
+  ]
+  return `${lines.filter(Boolean).join("\n")}\n`
+}
+
+/**
+ * Build the default CONTEXT.md content for a new project.
+ */
+function buildContext(projectName: string): string {
+  return [
+    `# ${projectName} — Session Context`,
+    "",
+    "This file stores technical context for session continuity.",
+    "The agent should update this file as work progresses.",
+    "",
+    "## Current State",
+    "",
+    "- Status: Initialized",
+    "- Last updated: (none)",
+    "",
+    "## Notes",
+    "",
+    "",
+  ].join("\n")
+}
+
+/**
+ * Atomic write-then-rename to prevent corruption.
+ */
+function atomicWrite(filePath: string, content: string): void {
+  const dir = filePath.substring(0, filePath.lastIndexOf("/"))
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true, mode: 0o700 })
+  }
+
+  const tmpPath = `${filePath}.tmp`
+  writeFileSync(tmpPath, content, { encoding: "utf8", mode: 0o600 })
+  renameSync(tmpPath, filePath)
+}

--- a/src/api/project-store.ts
+++ b/src/api/project-store.ts
@@ -5,8 +5,10 @@
  * ~/.openclaw/plugins/linear-light/projects/<slug>/
  *
  * Each project directory contains:
- * - README.md  — project overview with issue inventory
- * - CONTEXT.md — session continuity context for the agent
+ * - AGENTS.md   — project rules and instructions (agent must read first)
+ * - README.md   — project purpose and background
+ * - Context.md  — refined/extracted context for session continuity
+ * - issues/     — per-issue conversation records
  *
  * Follows the same atomic write-then-rename pattern as oauth-store.ts.
  */
@@ -54,13 +56,17 @@ export function ensureProjectDir(
     mkdirSync(dirPath, { recursive: true, mode: 0o700 })
     opts?.logger?.info(`Linear Light: created project directory ${dirPath}`)
 
-    // Initialize README.md
-    const readme = buildReadme(projectName, opts?.projectUrl)
-    atomicWrite(join(dirPath, "README.md"), readme)
+    // Initialize AGENTS.md (project rules — agent must read first)
+    atomicWrite(join(dirPath, "AGENTS.md"), buildAgentsMd(projectName))
 
-    // Initialize CONTEXT.md
-    const context = buildContext(projectName)
-    atomicWrite(join(dirPath, "CONTEXT.md"), context)
+    // Initialize README.md (project purpose and background)
+    atomicWrite(join(dirPath, "README.md"), buildReadme(projectName, opts?.projectUrl))
+
+    // Initialize Context.md (refined/extracted context)
+    atomicWrite(join(dirPath, "Context.md"), buildContext(projectName))
+
+    // Create issues/ directory
+    mkdirSync(join(dirPath, "issues"), { mode: 0o700 })
 
     opts?.logger?.info(`Linear Light: initialized project files for "${projectName}"`)
   }
@@ -83,7 +89,33 @@ export function resolveProjectInfo(
 }
 
 /**
- * Build the default README.md content for a new project.
+ * Build AGENTS.md — the project rules and instructions file.
+ * The agent must read this file first; it defines the conventions for all other files.
+ */
+function buildAgentsMd(projectName: string): string {
+  return [
+    `# ${projectName} — Agent Rules`,
+    "",
+    "Read this file first. It defines the rules for working with this project.",
+    "",
+    "## Project Directory Structure",
+    "",
+    "- `README.md` — Project purpose and background.",
+    "- `Context.md` — Refined/extracted context: technical state, key findings, architecture decisions. Update this as work progresses.",
+    "- `issues/` — Per-issue conversation records. Each issue gets `issues/<Identifier>.md`. Pull content from Linear API (comments), do not write manually.",
+    "- `AGENTS.md` — This file. Contains project rules and user instructions.",
+    "",
+    "## Instructions",
+    "",
+    "- Always read `Context.md` before starting work to understand current state.",
+    "- Update `Context.md` when making significant progress or discoveries.",
+    "- For issue conversation history, use the Linear API to pull comments into `issues/<Identifier>.md`.",
+    "",
+  ].join("\n")
+}
+
+/**
+ * Build README.md — project purpose and background.
  */
 function buildReadme(projectName: string, projectUrl?: string): string {
   const lines = [
@@ -91,31 +123,35 @@ function buildReadme(projectName: string, projectUrl?: string): string {
     "",
     projectUrl ? `Linear: ${projectUrl}` : "",
     "",
-    "## Issues",
+    "## Purpose",
     "",
-    "| Identifier | Title | Status | Priority |",
-    "| --- | --- | --- | --- |",
+    "",
+    "## Background",
+    "",
     "",
   ]
   return `${lines.filter(Boolean).join("\n")}\n`
 }
 
 /**
- * Build the default CONTEXT.md content for a new project.
+ * Build Context.md — refined/extracted context for session continuity.
  */
 function buildContext(projectName: string): string {
   return [
-    `# ${projectName} — Session Context`,
+    `# ${projectName} — Context`,
     "",
-    "This file stores technical context for session continuity.",
-    "The agent should update this file as work progresses.",
+    "Refined/extracted context for session continuity.",
+    "Update this file as work progresses.",
     "",
     "## Current State",
     "",
     "- Status: Initialized",
     "- Last updated: (none)",
     "",
-    "## Notes",
+    "## Key Findings",
+    "",
+    "",
+    "## Architecture Decisions",
     "",
     "",
   ].join("\n")

--- a/src/api/project-store.ts
+++ b/src/api/project-store.ts
@@ -15,22 +15,39 @@
 
 import { existsSync, mkdirSync, renameSync, writeFileSync } from "node:fs"
 import { homedir } from "node:os"
-import { join } from "node:path"
+import { dirname, join } from "node:path"
 
 import type { Logger } from "./linear-api.js"
 
 const PROJECTS_DIR = join(homedir(), ".openclaw", "plugins", "linear-light", "projects")
 
 /**
- * Convert a Linear project name to a URL-safe directory slug.
- * e.g. "EWL" → "ewl", "My Project" → "my-project", "API v2" → "api-v2"
+ * Convert a Linear project name and id to a unique, URL-safe directory slug.
+ * Includes a short hash of the project id to prevent collisions between
+ * projects whose names slugify to the same string (e.g. "A/B" and "AB").
+ * e.g. ("My Project", "abc123") → "my-project-a1b2c3"
  */
-export function slugifyProjectName(name: string): string {
-  return name
+export function slugifyProjectName(name: string, projectId?: string): string {
+  const nameSlug = name
     .toLowerCase()
     .trim()
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "")
+
+  if (!nameSlug) return projectId ? `proj-${shortHash(projectId)}` : ""
+
+  if (!projectId) return nameSlug
+
+  return `${nameSlug}-${shortHash(projectId)}`
+}
+
+/** Short deterministic hash from a string (first 6 hex chars of simple hash). */
+function shortHash(str: string): string {
+  let hash = 0
+  for (let i = 0; i < str.length; i++) {
+    hash = ((hash << 5) - hash + str.charCodeAt(i)) | 0
+  }
+  return Math.abs(hash).toString(16).padStart(6, "0").slice(0, 6)
 }
 
 /**
@@ -47,9 +64,9 @@ export function getProjectDir(slug: string): string {
  */
 export function ensureProjectDir(
   projectName: string,
-  opts?: { logger?: Logger; projectUrl?: string },
+  opts?: { logger?: Logger; projectUrl?: string; projectId?: string },
 ): { dirPath: string; slug: string } {
-  const slug = slugifyProjectName(projectName)
+  const slug = slugifyProjectName(projectName, opts?.projectId)
   const dirPath = getProjectDir(slug)
 
   if (!existsSync(dirPath)) {
@@ -84,7 +101,7 @@ export function resolveProjectInfo(
 ): { dirPath: string; slug: string; id: string; name: string } | null {
   if (!(project?.id && project?.name)) return null
 
-  const { dirPath, slug } = ensureProjectDir(project.name, opts)
+  const { dirPath, slug } = ensureProjectDir(project.name, { ...opts, projectId: project.id })
   return { id: project.id, name: project.name, slug, dirPath }
 }
 
@@ -200,7 +217,7 @@ function buildContext(projectName: string): string {
  * Atomic write-then-rename to prevent corruption.
  */
 function atomicWrite(filePath: string, content: string): void {
-  const dir = filePath.substring(0, filePath.lastIndexOf("/"))
+  const dir = dirname(filePath)
   if (!existsSync(dir)) {
     mkdirSync(dir, { recursive: true, mode: 0o700 })
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,15 @@ export interface LinearWebhookIssue {
   description?: string | null
   url: string
   team?: { id: string; key: string; name: string }
+  project?: { id: string; name: string } | null
+}
+
+/** Resolved project info from Linear API. */
+export interface ProjectInfo {
+  id: string
+  name: string
+  slug: string
+  dirPath: string
 }
 
 export interface LinearWebhookAgentSession {

--- a/src/webhook-handler.ts
+++ b/src/webhook-handler.ts
@@ -49,11 +49,11 @@ function formatInitialResponse(config: Record<string, unknown> | undefined, iden
 }
 
 /**
- * Build a project context section to inject into agent prompts.
+ * Build a project context hint to inject into agent prompts.
  * Returns empty string if the issue has no project or project memory is disabled.
  */
 function buildProjectContextSection(
-  issue: { project?: { id: string; name: string } | null; url?: string },
+  issue: { project?: { id: string; name: string } | null },
   config: Record<string, unknown> | undefined,
   logger?: Logger,
 ): string {
@@ -62,21 +62,7 @@ function buildProjectContextSection(
   const projectInfo = resolveProjectInfo(issue.project ?? null, { logger })
   if (!projectInfo) return ""
 
-  return [
-    "",
-    "---",
-    `**Project Memory** (${projectInfo.name}):`,
-    `This issue belongs to the Linear project "${projectInfo.name}".`,
-    `Project files are stored at: \`${projectInfo.dirPath}\``,
-    "",
-    "Before starting work:",
-    `- Read \`${projectInfo.dirPath}/CONTEXT.md\` for prior session context and technical state.`,
-    `- Read \`${projectInfo.dirPath}/README.md\` for the issue inventory and project overview.`,
-    "",
-    "When your work session ends or makes significant progress:",
-    `- Update \`${projectInfo.dirPath}/CONTEXT.md\` with current progress, findings, and next steps.`,
-    "- Commit and push the updated project files so future sessions can pick up where you left off.",
-  ].join("\n")
+  return `\n---\nProject memory: refer to \`${projectInfo.dirPath}\` and follow its rules.\n`
 }
 
 // Dedup tracking
@@ -287,7 +273,7 @@ async function handleSessionCreated(
     try {
       const details = await linearApi.getIssueDetails(issue.id)
       projectContext = buildProjectContextSection(
-        { project: details.project, url: details.url },
+        { project: details.project },
         config,
         api.logger as unknown as Logger,
       )
@@ -397,7 +383,7 @@ async function handleCommentCreate(
   const safeDescription = issue.description ? sanitizePromptInput(issue.description) : ""
 
   const projectContext = buildProjectContextSection(
-    { project: issue.project, url: issue.url },
+    { project: issue.project },
     config,
     api.logger as unknown as Logger,
   )

--- a/src/webhook-handler.ts
+++ b/src/webhook-handler.ts
@@ -16,6 +16,7 @@ import {
 import { agentSessionMap, identifierSessionMap } from "../index.js"
 import type { LinearAgentApi, Logger } from "./api/linear-api.js"
 import { resolveLinearToken } from "./api/linear-api.js"
+import { resolveProjectInfo } from "./api/project-store.js"
 import { setCompletionLoopConfig, startCompletionLoop } from "./completion-loop.js"
 import { getLinearApi, getLinearRuntime } from "./runtime.js"
 import type {
@@ -45,6 +46,37 @@ function getAgentIdentity(config: Record<string, unknown> | undefined): string {
 function formatInitialResponse(config: Record<string, unknown> | undefined, identifier: string, title: string): string {
   const template = (config?.initialResponseTemplate as string) || DEFAULT_INITIAL_RESPONSE_TEMPLATE
   return template.replace("{identifier}", identifier).replace("{title}", title)
+}
+
+/**
+ * Build a project context section to inject into agent prompts.
+ * Returns empty string if the issue has no project or project memory is disabled.
+ */
+function buildProjectContextSection(
+  issue: { project?: { id: string; name: string } | null; url?: string },
+  config: Record<string, unknown> | undefined,
+  logger?: Logger,
+): string {
+  if (config?.projectMemoryEnabled === false) return ""
+
+  const projectInfo = resolveProjectInfo(issue.project ?? null, { logger })
+  if (!projectInfo) return ""
+
+  return [
+    "",
+    "---",
+    `**Project Memory** (${projectInfo.name}):`,
+    `This issue belongs to the Linear project "${projectInfo.name}".`,
+    `Project files are stored at: \`${projectInfo.dirPath}\``,
+    "",
+    "Before starting work:",
+    `- Read \`${projectInfo.dirPath}/CONTEXT.md\` for prior session context and technical state.`,
+    `- Read \`${projectInfo.dirPath}/README.md\` for the issue inventory and project overview.`,
+    "",
+    "When your work session ends or makes significant progress:",
+    `- Update \`${projectInfo.dirPath}/CONTEXT.md\` with current progress, findings, and next steps.`,
+    "- Commit and push the updated project files so future sessions can pick up where you left off.",
+  ].join("\n")
 }
 
 // Dedup tracking
@@ -249,11 +281,27 @@ async function handleSessionCreated(
   const safeDescription = issue.description ? sanitizePromptInput(issue.description) : ""
   const sanitizedPrompt = sanitizePromptInput(prompt)
 
+  // Resolve project context — fetch issue details since webhook payload lacks project field
+  let projectContext = ""
+  if (linearApi && config?.projectMemoryEnabled !== false) {
+    try {
+      const details = await linearApi.getIssueDetails(issue.id)
+      projectContext = buildProjectContextSection(
+        { project: details.project, url: details.url },
+        config,
+        api.logger as unknown as Logger,
+      )
+    } catch (err) {
+      api.logger.warn(`Linear Light: failed to resolve project context: ${err}`)
+    }
+  }
+
   const body = [
     `[Linear Issue ${issue.identifier}] ${safeTitle}`,
     safeDescription ? `\n---\nDescription:\n${safeDescription}` : "",
     isMentionTriggered ? `\n---\n**User comment:**\n${sanitizedPrompt}` : "",
     `\n---\nIssue URL: ${issue.url}`,
+    projectContext,
     ``,
     getAgentIdentity(config),
   ].join("\n")
@@ -348,11 +396,18 @@ async function handleCommentCreate(
   const safeTitle = sanitizePromptInput(issue.title, 200)
   const safeDescription = issue.description ? sanitizePromptInput(issue.description) : ""
 
+  const projectContext = buildProjectContextSection(
+    { project: issue.project, url: issue.url },
+    config,
+    api.logger as unknown as Logger,
+  )
+
   const body = [
     `[Linear Issue ${issue.identifier}] ${safeTitle}`,
     safeDescription ? `\n---\nDescription:\n${safeDescription}` : "",
     `\n---\n**User comment:**\n${sanitizedPrompt}`,
     `\n---\nIssue URL: ${issue.url}`,
+    projectContext,
     ``,
     getAgentIdentity(config),
   ].join("\n")

--- a/src/webhook-handler.ts
+++ b/src/webhook-handler.ts
@@ -7,7 +7,9 @@
  */
 
 import { createHmac, timingSafeEqual } from "node:crypto"
+import { existsSync } from "node:fs"
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk"
+import { join } from "node:path"
 import {
   // @ts-expect-error — exported from local plugin-sdk but may not be in CI's version
   dispatchInboundReplyWithBase,
@@ -62,7 +64,24 @@ function buildProjectContextSection(
   const projectInfo = resolveProjectInfo(issue.project ?? null, { logger })
   if (!projectInfo) return ""
 
-  return `\n---\nProject memory: read \`${projectInfo.dirPath}/AGENTS.md\` first and follow its rules strictly.\n`
+  const files: string[] = []
+  for (const name of ["AGENTS.md", "Context.md", "README.md"]) {
+    if (existsSync(join(projectInfo.dirPath, name))) files.push(name)
+  }
+
+  const lines = [
+    `\n---\n📁 Project Memory for ${projectInfo.name}`,
+    `\nProject directory: \`${projectInfo.dirPath}\``,
+    `\n**Before starting work, read these files to restore context:**`,
+    ...files.map((f) => `- \`${f}\``),
+    `\n**When your session completes or you make significant progress:**`,
+    `1. Update \`${projectInfo.dirPath}/Context.md\` with current state, key decisions, and findings`,
+    `2. Update \`${projectInfo.dirPath}/README.md\` with progress and next steps`,
+    `3. Use \`project_memory_save\` tool to persist, or run \`cd ${projectInfo.dirPath} && git add -A && git commit -m "update: <summary>" && git push\``,
+    `\n`,
+  ]
+
+  return lines.join("\n")
 }
 
 /**

--- a/src/webhook-handler.ts
+++ b/src/webhook-handler.ts
@@ -8,8 +8,8 @@
 
 import { createHmac, timingSafeEqual } from "node:crypto"
 import { existsSync } from "node:fs"
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk"
 import { join } from "node:path"
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk"
 import {
   // @ts-expect-error — exported from local plugin-sdk but may not be in CI's version
   dispatchInboundReplyWithBase,

--- a/src/webhook-handler.ts
+++ b/src/webhook-handler.ts
@@ -62,7 +62,40 @@ function buildProjectContextSection(
   const projectInfo = resolveProjectInfo(issue.project ?? null, { logger })
   if (!projectInfo) return ""
 
-  return `\n---\nProject memory: refer to \`${projectInfo.dirPath}\` and follow its rules.\n`
+  return `\n---\nProject memory: read \`${projectInfo.dirPath}/AGENTS.md\` first and follow its rules strictly.\n`
+}
+
+/**
+ * Build project persistence update instructions for completion loop prompts.
+ * Returns empty string if project memory is disabled or no project found.
+ */
+async function buildCompletionProjectHint(
+  issueId: string,
+  issueIdentifier: string,
+  config: Record<string, unknown> | undefined,
+  logger?: Logger,
+): Promise<string> {
+  if (config?.projectMemoryEnabled === false) return ""
+
+  const linearApi = getLinearApi()
+  if (!linearApi) return ""
+
+  try {
+    const details = await linearApi.getIssueDetails(issueId)
+    const projectInfo = resolveProjectInfo(details.project, { logger })
+    if (!projectInfo) return ""
+
+    return [
+      "",
+      "---",
+      "Before responding, update the project memory files:",
+      `- Update \`${projectInfo.dirPath}/Context.md\` with current progress and findings.`,
+      `- Update \`${projectInfo.dirPath}/issues/${issueIdentifier}.md\` with conversation history (pull comments via Linear API, do not write manually).`,
+    ].join("\n")
+  } catch (err) {
+    logger?.warn(`Linear Light: failed to resolve project context for completion: ${err}`)
+    return ""
+  }
 }
 
 // Dedup tracking
@@ -551,8 +584,10 @@ export async function dispatchCompletionPrompt(
     return
   }
 
+  const projectHint = await buildCompletionProjectHint(issueId, issueIdentifier, ctx.config, _logger)
+
   const issue = { id: issueId, identifier: issueIdentifier, title: "", description: null, url: "" }
-  const body = [`[Linear ${issueIdentifier} completion check]`, prompt, ``, getAgentIdentity(ctx.config)].join("\n")
+  const body = [`[Linear ${issueIdentifier} completion check]`, prompt, projectHint, ``, getAgentIdentity(ctx.config)].join("\n")
 
   await dispatchToAgent(ctx.api, { issue, body, config: ctx.config })
 }

--- a/src/webhook-handler.ts
+++ b/src/webhook-handler.ts
@@ -308,7 +308,7 @@ async function handleSessionCreated(
         try {
           const projectInfo = resolveProjectInfo(details.project, { logger: api.logger as unknown as Logger })
           if (projectInfo) {
-            syncIssueConversation(projectInfo.dirPath, issue.identifier, details.comments.nodes)
+            syncIssueConversation(projectInfo.dirPath, issue.identifier, details.comments?.nodes ?? [])
           }
         } catch (err) {
           api.logger.warn(`Linear Light: failed to sync issue conversation: ${err}`)
@@ -361,7 +361,26 @@ async function handleSessionPrompted(
   captureDispatchContext(api, config, session.issue.id)
 
   const prompt = sanitizePromptInput(activity.content.body)
-  const body = [`[Linear ${session.issue.identifier} follow-up]`, prompt, ``, getAgentIdentity(config)].join("\n")
+
+  // Resolve project context — fetch issue details since webhook payload lacks project field
+  let projectContext = ""
+  const linearApi = makeLinearApi(config, api)
+  if (linearApi && config?.projectMemoryEnabled !== false) {
+    try {
+      const details = await linearApi.getIssueDetails(session.issue.id)
+      projectContext = buildProjectContextSection({ project: details.project }, config, api.logger as unknown as Logger)
+    } catch (err) {
+      api.logger.warn(`Linear Light: failed to resolve project context: ${err}`)
+    }
+  }
+
+  const body = [
+    `[Linear ${session.issue.identifier} follow-up]`,
+    prompt,
+    projectContext,
+    ``,
+    getAgentIdentity(config),
+  ].join("\n")
 
   await dispatchToAgent(api, { issue: session.issue, body, config })
 
@@ -426,7 +445,7 @@ async function handleCommentCreate(
     try {
       const projectInfo = resolveProjectInfo(issue.project, { logger: api.logger as unknown as Logger })
       if (projectInfo) {
-        syncIssueConversation(projectInfo.dirPath, issue.identifier, issue.comments.nodes)
+        syncIssueConversation(projectInfo.dirPath, issue.identifier, issue.comments?.nodes ?? [])
       }
     } catch (err) {
       api.logger.warn(`Linear Light: failed to sync issue conversation: ${err}`)

--- a/src/webhook-handler.ts
+++ b/src/webhook-handler.ts
@@ -16,7 +16,7 @@ import {
 import { agentSessionMap, identifierSessionMap } from "../index.js"
 import type { LinearAgentApi, Logger } from "./api/linear-api.js"
 import { resolveLinearToken } from "./api/linear-api.js"
-import { resolveProjectInfo } from "./api/project-store.js"
+import { resolveProjectInfo, syncIssueConversation } from "./api/project-store.js"
 import { setCompletionLoopConfig, startCompletionLoop } from "./completion-loop.js"
 import { getLinearApi, getLinearRuntime } from "./runtime.js"
 import type {
@@ -71,7 +71,6 @@ function buildProjectContextSection(
  */
 async function buildCompletionProjectHint(
   issueId: string,
-  issueIdentifier: string,
   config: Record<string, unknown> | undefined,
   logger?: Logger,
 ): Promise<string> {
@@ -88,9 +87,7 @@ async function buildCompletionProjectHint(
     return [
       "",
       "---",
-      "Before responding, update the project memory files:",
-      `- Update \`${projectInfo.dirPath}/Context.md\` with current progress and findings.`,
-      `- Update \`${projectInfo.dirPath}/issues/${issueIdentifier}.md\` with conversation history (pull comments via Linear API, do not write manually).`,
+      `Update \`${projectInfo.dirPath}/Context.md\` with current progress and findings before responding.`,
     ].join("\n")
   } catch (err) {
     logger?.warn(`Linear Light: failed to resolve project context for completion: ${err}`)
@@ -305,11 +302,18 @@ async function handleSessionCreated(
   if (linearApi && config?.projectMemoryEnabled !== false) {
     try {
       const details = await linearApi.getIssueDetails(issue.id)
-      projectContext = buildProjectContextSection(
-        { project: details.project },
-        config,
-        api.logger as unknown as Logger,
-      )
+      projectContext = buildProjectContextSection({ project: details.project }, config, api.logger as unknown as Logger)
+      // Auto-sync issue conversation to project's issues/ directory
+      if (details.project?.id) {
+        try {
+          const projectInfo = resolveProjectInfo(details.project, { logger: api.logger as unknown as Logger })
+          if (projectInfo) {
+            syncIssueConversation(projectInfo.dirPath, issue.identifier, details.comments.nodes)
+          }
+        } catch (err) {
+          api.logger.warn(`Linear Light: failed to sync issue conversation: ${err}`)
+        }
+      }
     } catch (err) {
       api.logger.warn(`Linear Light: failed to resolve project context: ${err}`)
     }
@@ -415,11 +419,19 @@ async function handleCommentCreate(
   const safeTitle = sanitizePromptInput(issue.title, 200)
   const safeDescription = issue.description ? sanitizePromptInput(issue.description) : ""
 
-  const projectContext = buildProjectContextSection(
-    { project: issue.project },
-    config,
-    api.logger as unknown as Logger,
-  )
+  const projectContext = buildProjectContextSection({ project: issue.project }, config, api.logger as unknown as Logger)
+
+  // Auto-sync issue conversation to project's issues/ directory
+  if (issue.project?.id) {
+    try {
+      const projectInfo = resolveProjectInfo(issue.project, { logger: api.logger as unknown as Logger })
+      if (projectInfo) {
+        syncIssueConversation(projectInfo.dirPath, issue.identifier, issue.comments.nodes)
+      }
+    } catch (err) {
+      api.logger.warn(`Linear Light: failed to sync issue conversation: ${err}`)
+    }
+  }
 
   const body = [
     `[Linear Issue ${issue.identifier}] ${safeTitle}`,
@@ -546,10 +558,7 @@ let _logger: Logger = console as unknown as Logger
  * Store a fallback api/config for use when per-issue context is unavailable
  * (e.g. after gateway restart when completion loops resume from persistence).
  */
-export function setFallbackDispatchContext(
-  api: OpenClawPluginApi,
-  config: Record<string, unknown> | undefined,
-): void {
+export function setFallbackDispatchContext(api: OpenClawPluginApi, config: Record<string, unknown> | undefined): void {
   _fallbackContext = { api, config }
 }
 
@@ -584,10 +593,16 @@ export async function dispatchCompletionPrompt(
     return
   }
 
-  const projectHint = await buildCompletionProjectHint(issueId, issueIdentifier, ctx.config, _logger)
+  const projectHint = await buildCompletionProjectHint(issueId, ctx.config, _logger)
 
   const issue = { id: issueId, identifier: issueIdentifier, title: "", description: null, url: "" }
-  const body = [`[Linear ${issueIdentifier} completion check]`, prompt, projectHint, ``, getAgentIdentity(ctx.config)].join("\n")
+  const body = [
+    `[Linear ${issueIdentifier} completion check]`,
+    prompt,
+    projectHint,
+    ``,
+    getAgentIdentity(ctx.config),
+  ].join("\n")
 
   await dispatchToAgent(ctx.api, { issue, body, config: ctx.config })
 }


### PR DESCRIPTION
## Summary
- Refined project directory structure with role-separated files: `AGENTS.md` (rules), `README.md` (purpose), `Context.md` (refined context, written by agent), `issues/` (conversation records, auto-managed by plugin)
- Plugin automatically pulls issue comments via Linear API and writes them to `issues/<Identifier>.md` on session created and comment create
- Initial prompt hint emphasizes reading `AGENTS.md` first
- Completion loop only reminds agent to update `Context.md`
- Controlled by `projectMemoryEnabled` config flag (default: enabled)

## Implementation
- **`src/api/project-store.ts`** — `syncIssueConversation()` writes `issues/<Identifier>.md` from Linear API comments. `AGENTS.md` clarifies that `issues/` is auto-managed and `Context.md` should be written by the agent.
- **`src/webhook-handler.ts`** — Calls `syncIssueConversation()` from `handleSessionCreated` and `handleCommentCreate` (best-effort, wrapped in try-catch). `buildCompletionProjectHint()` only reminds about `Context.md`.
- **`src/types.ts`** — Added `project` field to `LinearWebhookIssue` and `ProjectInfo` interface.

## Testing
- 30 new tests: 26 for project-store (including 5 for syncIssueConversation), 7 for webhook-handler (including completion loop project hint)
- All 261 tests passing, coverage ≥90% (Statements 96.02%, Branches 90.97%, Functions 95%, Lines 97.43%)
- TypeScript strict mode clean, biome lint clean (no new errors)

Closes DEV-197

---

> **Tip:** I will respond to comments that @ mention @cyrusagent on this PR. You can also submit a "changes requested" review with all your feedback at once, and I will automatically wake up to address each comment.

<!-- generated-by-cyrus -->