### PR TITLE
feat: add gateway watchdog command

### DIFF
--- a/src/__test__/watchdog.test.ts
+++ b/src/__test__/watchdog.test.ts
@@ -1,0 +1,262 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+// ---------------------------------------------------------------------------
+// Watchdog unit tests
+// ---------------------------------------------------------------------------
+
+// Mock fetch globally
+const mockFetch = vi.fn()
+vi.stubGlobal("fetch", mockFetch)
+
+// Mock node:fs for FileTokenStore
+const mockReadFileSync = vi.fn()
+const mockExistsSync = vi.fn(() => true)
+vi.mock("node:fs", () => ({
+  existsSync: mockExistsSync,
+  mkdirSync: vi.fn(),
+  readFileSync: mockReadFileSync,
+  writeFileSync: vi.fn(),
+}))
+
+// Mock node:child_process for pm2 repair
+const mockExecSync = vi.fn()
+vi.mock("node:child_process", () => ({
+  execSync: mockExecSync,
+}))
+
+// Mock node:os homedir
+vi.mock("node:os", () => ({
+  homedir: () => "/home/test",
+}))
+
+// Mock node:path
+vi.mock("node:path", () => ({
+  join: (...args: string[]) => args.join("/"),
+  dirname: (p: string) => p.split("/").slice(0, -1).join("/") || ".",
+}))
+
+describe("runWatchdog", () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    // Default: network OK, token OK, gateway OK
+    mockFetch.mockImplementation((url: string, opts?: { body?: string }) => {
+      const body = opts?.body ? JSON.parse(opts.body) : null
+      const query = body?.query ?? ""
+
+      // Network connectivity check (no auth header)
+      if (!opts?.headers?.Authorization && query === "{ __typename }") {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ data: { __typename: "QueryRoot" } }),
+        })
+      }
+
+      // Token validity check (with auth)
+      if (query.includes("viewer")) {
+        const auth = opts?.headers?.Authorization
+        if (auth?.includes("valid-token")) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ data: { viewer: { id: "user-1", name: "Test" } } }),
+          })
+        }
+        return Promise.resolve({ ok: false, status: 401, text: () => Promise.resolve("Unauthorized") })
+      }
+
+      // Gateway health check
+      if (url?.includes("/health")) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ status: "ok", uptime: 3600 }) })
+      }
+
+      return Promise.resolve({ ok: false, status: 404 })
+    })
+
+    // Default: token file exists with valid token
+    mockReadFileSync.mockReturnValue(
+      JSON.stringify({
+        accessToken: "valid-token",
+        refreshToken: "refresh-token",
+        expiresAt: Date.now() + 86400000,
+      }),
+    )
+    mockExistsSync.mockReturnValue(true)
+  })
+
+  it("reports healthy when all checks pass", async () => {
+    const { runWatchdog } = await import("../standalone/watchdog.js")
+    const report = await runWatchdog({})
+
+    expect(report.healthy).toBe(true)
+    expect(report.checks).toHaveLength(3)
+    expect(report.checks[0].name).toBe("network")
+    expect(report.checks[0].ok).toBe(true)
+    expect(report.checks[1].name).toBe("token")
+    expect(report.checks[1].ok).toBe(true)
+    expect(report.checks[2].name).toBe("gateway")
+    expect(report.checks[2].ok).toBe(true)
+  })
+
+  it("reports unhealthy when network is unreachable", async () => {
+    mockFetch.mockImplementation(() => {
+      const err = new Error("fetch failed")
+      throw err
+    })
+
+    const { runWatchdog } = await import("../standalone/watchdog.js")
+    const report = await runWatchdog({})
+
+    expect(report.healthy).toBe(false)
+    expect(report.checks).toHaveLength(1) // early exit after network failure
+    expect(report.checks[0].name).toBe("network")
+    expect(report.checks[0].ok).toBe(false)
+  })
+
+  it("reports unhealthy when token is expired", async () => {
+    mockFetch.mockImplementation((url: string, opts?: { body?: string }) => {
+      const body = opts?.body ? JSON.parse(opts.body) : null
+      const query = body?.query ?? ""
+
+      if (!opts?.headers?.Authorization && query === "{ __typename }") {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ data: { __typename: "QueryRoot" } }),
+        })
+      }
+
+      if (query.includes("viewer")) {
+        return Promise.resolve({ ok: false, status: 401, text: () => Promise.resolve("Unauthorized") })
+      }
+
+      if (url?.includes("/health")) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ status: "ok", uptime: 3600 }) })
+      }
+
+      return Promise.resolve({ ok: false, status: 404 })
+    })
+
+    const { runWatchdog } = await import("../standalone/watchdog.js")
+    const report = await runWatchdog({})
+
+    expect(report.healthy).toBe(false)
+    expect(report.checks.find((c) => c.name === "token")?.ok).toBe(false)
+  })
+
+  it("reports unhealthy when gateway is down", async () => {
+    mockFetch.mockImplementation((url: string, opts?: { body?: string }) => {
+      const body = opts?.body ? JSON.parse(opts.body) : null
+      const query = body?.query ?? ""
+
+      if (!opts?.headers?.Authorization && query === "{ __typename }") {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ data: { __typename: "QueryRoot" } }),
+        })
+      }
+
+      if (query.includes("viewer")) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ data: { viewer: { id: "user-1", name: "Test" } } }),
+        })
+      }
+
+      if (url?.includes("/health")) {
+        const err = new Error("ECONNREFUSED")
+        throw err
+      }
+
+      return Promise.resolve({ ok: false, status: 404 })
+    })
+
+    const { runWatchdog } = await import("../standalone/watchdog.js")
+    const report = await runWatchdog({})
+
+    expect(report.healthy).toBe(false)
+    expect(report.checks.find((c) => c.name === "gateway")?.ok).toBe(false)
+  })
+
+  it("attempts pm2 restart when gateway is down and --fix is set", async () => {
+    mockFetch.mockImplementation((url: string, opts?: { body?: string }) => {
+      const body = opts?.body ? JSON.parse(opts.body) : null
+      const query = body?.query ?? ""
+
+      if (!opts?.headers?.Authorization && query === "{ __typename }") {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ data: { __typename: "QueryRoot" } }),
+        })
+      }
+
+      if (query.includes("viewer")) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ data: { viewer: { id: "user-1", name: "Test" } } }),
+        })
+      }
+
+      if (url?.includes("/health")) {
+        const err = new Error("ECONNREFUSED")
+        throw err
+      }
+
+      return Promise.resolve({ ok: false, status: 404 })
+    })
+
+    mockExecSync.mockReturnValue(Buffer.from("restarted"))
+
+    const { runWatchdog } = await import("../standalone/watchdog.js")
+    const report = await runWatchdog({ fix: true })
+
+    expect(report.healthy).toBe(false)
+    const gatewayCheck = report.checks.find((c) => c.name === "gateway")
+    expect(gatewayCheck?.repaired).toBe(true)
+    expect(mockExecSync).toHaveBeenCalledWith("pm2 restart linear-gateway", expect.any(Object))
+  })
+
+  it("uses custom port when provided", async () => {
+    const { runWatchdog } = await import("../standalone/watchdog.js")
+    await runWatchdog({ port: 9091 })
+
+    // Check that one of the fetch calls used the custom port
+    const healthCall = mockFetch.mock.calls.find((call: unknown[]) => String(call[0]).includes("/health"))
+    expect(healthCall?.[0]).toContain("9091")
+  })
+
+  it("reports no token when token store is empty", async () => {
+    mockReadFileSync.mockReturnValue("{}")
+
+    const { runWatchdog } = await import("../standalone/watchdog.js")
+    const report = await runWatchdog({})
+
+    expect(report.healthy).toBe(false)
+    const tokenCheck = report.checks.find((c) => c.name === "token")
+    expect(tokenCheck?.ok).toBe(false)
+    expect(tokenCheck?.detail).toContain("no token found")
+  })
+
+  it("skips token and gateway checks when network is down (early exit)", async () => {
+    mockFetch.mockImplementation((_url: string, opts?: { body?: string }) => {
+      const body = opts?.body ? JSON.parse(opts.body) : null
+      const query = body?.query ?? ""
+
+      // Network check returns 401 (reachable but unauthenticated — fine for network check)
+      if (!opts?.headers?.Authorization && query === "{ __typename }") {
+        return Promise.resolve({ ok: false, status: 503 })
+      }
+
+      // If we get here, the test is wrong
+      throw new Error("Should not reach token/gateway checks")
+    })
+
+    const { runWatchdog } = await import("../standalone/watchdog.js")
+    const report = await runWatchdog({})
+
+    // Network 503 is not 200/401, so it should report unhealthy and early-exit
+    expect(report.healthy).toBe(false)
+    expect(report.checks).toHaveLength(1)
+  })
+})

--- a/src/standalone/cli.ts
+++ b/src/standalone/cli.ts
@@ -13,11 +13,12 @@
  * Reads token from ~/.linear-gateway/token.json or LINEAR_API_TOKEN env var.
  */
 
+import { existsSync, readFileSync } from "node:fs"
 import { homedir } from "node:os"
 import { join } from "node:path"
-import { existsSync, readFileSync } from "node:fs"
 import { LinearAgentApi, resolveLinearToken } from "../core/linear-client.js"
 import { FileTokenStore } from "./token-store.js"
+import { runWatchdog, type WatchdogOptions } from "./watchdog.js"
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -67,7 +68,9 @@ Commands:
   status <issue-id> <state>   Update issue status (e.g. "In Progress", "Done")
   emit <session-id> <body>    Emit activity to an agent session
   get <issue-id>              Get issue details (JSON)
-  search <query>              Search issues (JSON)`)
+  search <query>              Search issues (JSON)
+  watchdog [--port N] [--fix] [--json]
+                              Health-check the gateway (token, network, process)`)
 }
 
 // ---------------------------------------------------------------------------
@@ -87,7 +90,7 @@ async function cmdComment(api: LinearAgentApi, args: string[]): Promise<void> {
 
 async function cmdStatus(api: LinearAgentApi, args: string[]): Promise<void> {
   const [issueId, stateName] = args
-  if (!issueId || !stateName) {
+  if (!(issueId && stateName)) {
     console.error("Usage: linear status <issue-id> <state-name>")
     process.exit(1)
   }
@@ -123,7 +126,9 @@ async function cmdSearch(api: LinearAgentApi, args: string[]): Promise<void> {
     process.exit(1)
   }
   const data = await api.gql<{
-    issueSearch: { nodes: Array<{ id: string; identifier: string; title: string; state: { name: string }; url: string }> }
+    issueSearch: {
+      nodes: Array<{ id: string; identifier: string; title: string; state: { name: string }; url: string }>
+    }
   }>(
     `query($query: String!, $first: Int) {
       issueSearch(query: $query, first: $first) {
@@ -135,12 +140,43 @@ async function cmdSearch(api: LinearAgentApi, args: string[]): Promise<void> {
   console.log(JSON.stringify(data.issueSearch.nodes, null, 2))
 }
 
+async function cmdWatchdog(args: string[]): Promise<void> {
+  const opts: WatchdogOptions = {}
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--port" && args[i + 1]) {
+      opts.port = Number.parseInt(args[++i], 10)
+    } else if (args[i] === "--fix") {
+      opts.fix = true
+    } else if (args[i] === "--json") {
+      opts.json = true
+    } else if (args[i] === "--token-store" && args[i + 1]) {
+      opts.tokenStorePath = args[++i]
+    }
+  }
+
+  const report = await runWatchdog(opts)
+
+  if (opts.json) {
+    console.log(JSON.stringify(report, null, 2))
+  } else {
+    const status = report.healthy ? "✅ healthy" : "❌ unhealthy"
+    console.log(`[${new Date().toISOString()}] ${status}`)
+    for (const check of report.checks) {
+      const icon = check.ok ? "✓" : "✗"
+      const repair = check.repaired ? " [REPAIRED]" : ""
+      console.log(`  ${icon} ${check.name}: ${check.detail ?? "ok"}${repair}`)
+    }
+  }
+
+  process.exit(report.healthy ? 0 : 1)
+}
+
 // ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 
 async function main(): Promise<void> {
-  const [,, command, ...args] = process.argv
+  const [, , command, ...args] = process.argv
 
   if (!command || command === "help" || command === "-h") {
     printUsage()
@@ -165,6 +201,9 @@ async function main(): Promise<void> {
     case "search":
       await cmdSearch(api, args)
       break
+    case "watchdog":
+      await cmdWatchdog(args)
+      return // watchdog handles its own exit code
     default:
       console.error(`Unknown command: ${command}`)
       printUsage()

--- a/src/standalone/watchdog.ts
+++ b/src/standalone/watchdog.ts
@@ -1,0 +1,220 @@
+/**
+ * Linear Gateway Watchdog — health check + auto-repair for standalone gateway.
+ *
+ * Checks three failure modes:
+ *   1. Token validity (GraphQL viewer query)
+ *   2. Gateway process (HTTP health endpoint)
+ *   3. Network connectivity (can reach Linear API at all)
+ *
+ * Designed to be called from cron or systemd timer. Exits 0 when healthy,
+ * exits 1 when unhealthy (after attempting repair).
+ *
+ * Usage:
+ *   linear watchdog [--port 8091] [--fix] [--json]
+ */
+
+import { resolveLinearToken } from "../core/linear-client.js"
+import { FileTokenStore } from "./token-store.js"
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface WatchdogOptions {
+  /** Gateway HTTP port (default: 8091) */
+  port?: number
+  /** Attempt auto-repair on failure */
+  fix?: boolean
+  /** Output results as JSON */
+  json?: boolean
+  /** Token store path override */
+  tokenStorePath?: string
+}
+
+export type CheckResult = {
+  name: string
+  ok: boolean
+  detail?: string
+  repaired?: boolean
+}
+
+export interface WatchdogReport {
+  timestamp: string
+  checks: CheckResult[]
+  healthy: boolean
+}
+
+// ---------------------------------------------------------------------------
+// Defaults
+// ---------------------------------------------------------------------------
+
+const DEFAULT_PORT = 8091
+const GATEWAY_TIMEOUT_MS = 5000
+const API_TIMEOUT_MS = 10000
+
+// ---------------------------------------------------------------------------
+// Checkers
+// ---------------------------------------------------------------------------
+
+/**
+ * Check 1: Can we reach the Linear GraphQL API at all?
+ * Distinguishes "network is broken" from "token is expired".
+ */
+async function checkNetworkConnectivity(): Promise<CheckResult> {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), API_TIMEOUT_MS)
+
+  try {
+    const res = await fetch("https://api.linear.app/graphql", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ query: "{ __typename }" }),
+      signal: controller.signal,
+    })
+    clearTimeout(timer)
+
+    // 401 is fine — it means we can reach the API, just not authenticated
+    if (res.status === 401 || res.status === 200) {
+      return { name: "network", ok: true, detail: `HTTP ${res.status}` }
+    }
+    return { name: "network", ok: false, detail: `HTTP ${res.status}` }
+  } catch (err) {
+    clearTimeout(timer)
+    const msg = err instanceof Error ? err.message : String(err)
+    return { name: "network", ok: false, detail: msg }
+  }
+}
+
+/**
+ * Check 2: Can we authenticate with the current token?
+ * Uses a lightweight viewer query.
+ */
+async function checkTokenValidity(tokenStorePath: string): Promise<CheckResult> {
+  const tokenStore = new FileTokenStore(tokenStorePath)
+  const tokenInfo = resolveLinearToken(undefined, tokenStore)
+
+  if (!tokenInfo.accessToken) {
+    return { name: "token", ok: false, detail: "no token found in store" }
+  }
+
+  try {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), API_TIMEOUT_MS)
+
+    const res = await fetch("https://api.linear.app/graphql", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: tokenInfo.refreshToken ? `Bearer ${tokenInfo.accessToken}` : tokenInfo.accessToken,
+      },
+      body: JSON.stringify({ query: "{ viewer { id name } }" }),
+      signal: controller.signal,
+    })
+    clearTimeout(timer)
+
+    if (res.ok) {
+      const payload = (await res.json()) as { data?: { viewer?: { id: string; name: string } } }
+      if (payload.data?.viewer?.id) {
+        return { name: "token", ok: true, detail: `viewer: ${payload.data.viewer.name}` }
+      }
+      return { name: "token", ok: false, detail: "viewer query returned no data" }
+    }
+
+    return { name: "token", ok: false, detail: `HTTP ${res.status}` }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    return { name: "token", ok: false, detail: msg }
+  }
+}
+
+/**
+ * Check 3: Is the gateway process responding on its health endpoint?
+ */
+async function checkGatewayHealth(port: number): Promise<CheckResult> {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), GATEWAY_TIMEOUT_MS)
+
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/health`, {
+      signal: controller.signal,
+    })
+    clearTimeout(timer)
+
+    if (res.ok) {
+      const payload = (await res.json()) as { status?: string; uptime?: number }
+      return {
+        name: "gateway",
+        ok: true,
+        detail: `uptime: ${payload.uptime ?? "unknown"}s`,
+      }
+    }
+    return { name: "gateway", ok: false, detail: `HTTP ${res.status}` }
+  } catch (err) {
+    clearTimeout(timer)
+    const msg = err instanceof Error ? err.message : String(err)
+    return { name: "gateway", ok: false, detail: msg }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Auto-repair
+// ---------------------------------------------------------------------------
+
+async function attemptRepair(checks: CheckResult[]): Promise<void> {
+  for (const check of checks) {
+    if (check.ok) continue
+
+    // Gateway is down — try pm2 restart
+    if (check.name === "gateway") {
+      const { execSync } = await import("node:child_process")
+      try {
+        execSync("pm2 restart linear-gateway", { timeout: 15000, stdio: "pipe" })
+        check.repaired = true
+        check.detail += " [restarted via pm2]"
+      } catch {
+        check.detail += " [pm2 restart failed]"
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+export async function runWatchdog(opts: WatchdogOptions): Promise<WatchdogReport> {
+  const { homedir } = await import("node:os")
+  const { join } = await import("node:path")
+  const port = opts.port ?? DEFAULT_PORT
+  const tokenStorePath = opts.tokenStorePath ?? join(homedir(), ".linear-gateway", "token.json")
+
+  const checks: CheckResult[] = []
+
+  // Run checks in order — network first (fastest failure signal)
+  checks.push(await checkNetworkConnectivity())
+  if (!checks[0].ok) {
+    // Network is down — skip token and gateway checks
+    const report: WatchdogReport = {
+      timestamp: new Date().toISOString(),
+      checks,
+      healthy: false,
+    }
+    if (opts.fix) await attemptRepair(checks)
+    return report
+  }
+
+  checks.push(await checkTokenValidity(tokenStorePath))
+  checks.push(await checkGatewayHealth(port))
+
+  const healthy = checks.every((c) => c.ok)
+
+  if (!healthy && opts.fix) {
+    await attemptRepair(checks)
+  }
+
+  return {
+    timestamp: new Date().toISOString(),
+    checks,
+    healthy,
+  }
+}


### PR DESCRIPTION
## Summary

Add `linear watchdog` CLI subcommand for standalone gateway health monitoring.

### Three independent checks

| Check | What it verifies |
|-------|-----------------|
| **network** | Can we reach `api.linear.app` at all? (Distinguishes broken network from expired token) |
| **token** | Does the current token in `~/.linear-gateway/token.json` authenticate successfully? (viewer query) |
| **gateway** | Is the gateway HTTP server responding on `/health`? |

### Auto-repair

With `--fix`, automatically restarts the gateway via `pm2 restart linear-gateway` when the health endpoint is unreachable.

### Usage

```bash
# One-shot check (exit 0 = healthy, 1 = unhealthy)
linear watchdog

# With auto-repair
linear watchdog --fix

# Custom port + JSON output (for cron logging)
linear watchdog --port 9091 --json
```

### Cron integration

```
*/3 * * * * linear watchdog --fix --json >> /var/log/linear-watchdog.log 2>&1
```

### Implementation

- `src/standalone/watchdog.ts` — Core logic, reuses `FileTokenStore` and `resolveLinearToken`
- `src/standalone/cli.ts` — CLI subcommand with `--port`, `--fix`, `--json`, `--token-store` flags
- `src/__test__/watchdog.test.ts` — 8 unit tests covering all failure modes and repair

No new runtime dependencies. Follows existing project conventions (ESM, strict TS, Biome, Vitest).