### PR TITLE
docs: rewrite README — two-mode architecture, standalone gateway, Hermes parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,44 +4,81 @@ Turn every Linear issue into an AI agent session. No Slack bot, no Telegram brid
 
 ## Why Linear, Not Chat
 
-Most AI agent workflows run inside chat apps: Telegram, Slack, Feishu. You type a request, the agent replies, the conversation scrolls away.
+Most AI agent workflows run inside chat apps. You type a request, the agent replies, the conversation scrolls away.
 
-Linear is different. Here's why that matters for agent work:
+Linear is different.
 
-**Issues force you to write.** Before an agent can work on something, someone has to create an issue — give it a title, write a description, assign it, set a priority. That friction is a feature. It forces the human to think clearly about what they want. Vague requests like "fix the thing" don't survive the issue creation flow.
+**Issues force you to write.** Before an agent can work on something, someone has to create an issue — give it a title, write a description, assign it, set a priority. That friction is a feature. It forces the human to think clearly. Vague requests like "fix the thing" don't survive the issue creation flow.
 
-**Status is visible.** In a chat, an agent says "I'll do it" and you hope for the best. In Linear, the issue moves from "Todo" to "In Progress" to "Done" — and everyone on the team can see it. The status board is a shared understanding of what's happening.
+**Status is visible.** In a chat, an agent says "I'll do it" and you hope for the best. In Linear, the issue moves from "Todo" to "In Progress" to "Done" — and everyone on the team can see it.
 
-**Context persists.** A chat thread gets buried. An issue stays in your project, searchable, linkable, with a full comment history of what the agent did and why. You can come back to it three months later and understand the full arc.
+**Context persists.** A chat thread gets buried. An issue stays in your project, searchable, linkable, with a full comment history. You can come back three months later and understand the full arc.
 
-**Assignment creates accountability.** When you assign an issue to a person (or an agent), there's a clear owner. No more "I thought you were doing it" — the assignee field settles it.
+**Assignment creates accountability.** When you assign an issue to a person (or an agent), there's a clear owner. No more "I thought you were doing it."
 
-We're not saying chat is bad. Chat is great for quick questions and casual collaboration. But for structured work that an agent should own end-to-end, the issue tracker is the right abstraction.
+We're not saying chat is bad. Chat is great for quick questions. But for structured work that an agent should own end-to-end, the issue tracker is the right abstraction.
+
+## Two Modes
+
+Linear Light works in two modes, sharing the same core logic:
+
+**OpenClaw Plugin** — runs as a plugin inside an [OpenClaw](https://github.com/nousresearch/openclaw) gateway. Uses OpenClaw's built-in agent, completion loop, and real-time activity streaming. Best if you're already on OpenClaw.
+
+**Standalone Gateway** — runs independently, forwarding Linear webhooks to [Hermes Agent](https://hermes-agent.nousresearch.com/) or any webhook-compatible agent. No OpenClaw dependency. Best if you want a lightweight setup or prefer Hermes's skills, MCP integration, and multi-platform reply delivery.
+
+Both modes share the same Linear API client, webhook verification, project memory, and token management. The core modules live in `src/core/`.
+
+```
+                  Linear webhook
+                       │
+                       ▼
+              ┌────────────────┐
+              │  Linear Light  │
+              │  (shared core) │
+              └───┬────────┬───┘
+                  │        │
+          OpenClaw    Standalone
+          Plugin      Gateway
+                  │        │
+                  ▼        ▼
+          OpenClaw     Hermes
+          Agent        Agent
+```
+
+### Feature Comparison
+
+| | OpenClaw Plugin | Standalone Gateway |
+|---|---|---|
+| Real-time activity streaming | Yes | No |
+| Completion loop | Built-in | Via Hermes cron |
+| Multi-platform reply | Linear only | 15+ platforms (Hermes) |
+| MCP / Skills / Memory | OpenClaw's | Hermes's |
+| Zero external deps | Yes | Yes (Node.js built-ins) |
+| Requires OpenClaw | Yes | No |
+| Requires Hermes | No | Yes |
 
 ## How It Works
 
-Linear is registered as a first-class OpenClaw channel. When you trigger the agent on an issue — via @mention or Linear's built-in agent sessions — the plugin receives a webhook, dispatches the message to the agent, and posts the reply back as a comment.
-
 ```
-Linear issue trigger
+Linear issue trigger (@mention or agent session)
        │
        ▼
-  Webhook (signed, deduped)
+  Webhook (HMAC-SHA256 signed, deduped)
        │
        ▼
-  OpenClaw agent session
+  Agent session — one per issue
        │
-       ├─ thoughts / tool calls → Linear agent session UI (real-time)
+       ├─ thoughts / tool calls → Linear agent session UI (OpenClaw mode)
        └─ final reply → comment on the issue
 ```
 
-Each issue maps to one persistent session. Follow-up comments continue the conversation. The agent has access to all its tools, skills, and memory — the same capabilities it has in any other channel.
+Each issue maps to one persistent session. Follow-up comments continue the conversation. The agent has full tool access — Linear API, file system, terminal, web, whatever its backend provides.
 
 ## Project Memory
 
 An agent session starts fresh every time. If an issue sits dormant for a week and someone adds a follow-up comment, the agent wakes up with no memory of what happened before.
 
-Project memory solves this. When an issue belongs to a Linear project, the plugin automatically maintains a directory on your local machine:
+Project memory solves this. When an issue belongs to a Linear project, the plugin maintains a directory on your local machine:
 
 ```
 ~/clawd/projects/<project-name>-<hash>/
@@ -51,71 +88,100 @@ Project memory solves this. When an issue belongs to a Linear project, the plugi
 └── issues/       # Conversation records, auto-synced from Linear
 ```
 
-Before starting work, the agent reads `Context.md` to understand where things left off. When it makes progress, it updates `Context.md` with new findings. When the session ends, it commits and pushes to git.
+Before starting work, the agent reads `Context.md`. When it makes progress, it updates `Context.md` and commits to git.
 
-It's deliberately simple. No database, no vector store, no embedding model. Just a few markdown files that the agent can read and write. This works because:
+This is deliberately simple. No database, no vector store, no embedding model. Just markdown files. It works because:
 
-1. **The agent is the reader and writer.** It doesn't need search or retrieval — it reads the whole file. Markdown is its native format.
-2. **Git provides versioning.** Every update is a commit. You can diff, revert, and see the full history of how the agent's understanding evolved.
-3. **The directory structure is self-documenting.** `AGENTS.md` at the top means "read this first." `Context.md` means "here's what we know." No schema to learn.
-4. **It's local and private.** Everything stays on your machine. No data leaves your filesystem.
+1. **The agent is both reader and writer.** No search or retrieval needed — it reads the whole file.
+2. **Git provides versioning.** Every update is a commit. Diff, revert, see the evolution.
+3. **Self-documenting structure.** `AGENTS.md` = read this first. `Context.md` = here's what we know.
+4. **Local and private.** Nothing leaves your filesystem.
 
 We tried more complex approaches. This is the one that stuck.
 
-## Completion Loop
+## Completion Loop (OpenClaw Mode)
 
-When an agent works on an issue, it might not finish in one pass. Maybe it needs to wait for a long-running command. Maybe it gets stuck. Maybe the task is genuinely multi-step and requires multiple iterations.
+In chat, you'd nudge the agent: "hey, are you done?" In Linear, there's nobody watching.
 
-In a chat, you'd just nudge the agent: "hey, are you done?" In Linear, there's nobody watching.
+The completion loop checks every N minutes (default 10) whether the issue is still in a non-terminal state. If it is, it sends the agent a prompt to continue. The loop stops at "Done" or "Canceled."
 
-The completion loop is a periodic check: every N minutes (configurable, default 10), the plugin checks whether the issue is still in a non-terminal state. If it is, it sends the agent a prompt to continue working. The loop stops when the issue reaches "Done" or "Canceled."
+- Agent doesn't silently give up after timeouts
+- Multi-step tasks complete without human intervention
+- State persists to disk — survives gateway restarts
 
-This sounds simple. It is simple. But it solves a real problem:
+In standalone mode, use Hermes's built-in cron scheduler for the same effect.
 
-- **The agent doesn't silently give up.** If a long operation times out, the next loop tick picks it up.
-- **Multi-step tasks get completed.** The agent can make progress across multiple iterations without human intervention.
-- **Linear needs it more than chat.** In chat, there's a human in the loop who notices when things stall. In Linear, issues can sit in "In Progress" forever. The loop is the safety net.
+## Standalone Gateway
 
-Loop state is persisted to disk, so it survives gateway restarts. If the server goes down and comes back up, the loop resumes and checks whether the issue is already done before prompting the agent again.
+Run Linear Light without OpenClaw:
 
-## Real-Time Activity Streaming
+```bash
+# Install
+git clone https://github.com/QiuYi111/linear-light.git
+cd linear-light
+npm install
 
-While the agent works, you can watch its progress in Linear's agent session UI:
+# Configure — create ~/.linear-gateway/config.json or use env vars
+# Required: LINEAR_WEBHOOK_SECRET, HERMES_WEBHOOK_URL, HERMES_ROUTE_SECRET
 
-- **Thoughts** — the agent's reasoning, streamed as it generates
-- **Actions** — tool calls, shown as start/complete markers
-- **Responses** — the final reply, posted as a permanent comment
+# Start
+npx tsx src/standalone/index.ts
 
-This gives you visibility into what the agent is doing without having to open a separate terminal or dashboard. The agent session UI in Linear was designed for exactly this — we just connect to it.
+# Or install globally for the CLI
+npm link
+linear watchdog --fix     # Health check + auto-repair
+```
+
+The standalone gateway includes:
+
+- **Anti-loop protection** — terminal state guard prevents dispatching on already-completed issues
+- **Token management** — OAuth flow with automatic refresh
+- **Watchdog** — `linear watchdog` checks token validity, gateway health, and network connectivity; `--fix` attempts auto-repair
+
+### Standalone Config
+
+Config file at `~/.linear-gateway/config.json` (or env vars):
+
+| Field | Env Var | Description |
+|---|---|---|
+| `port` | `LINEAR_GATEWAY_PORT` | HTTP port (default: 8091) |
+| `linear.webhookSecret` | `LINEAR_WEBHOOK_SECRET` | Linear webhook signing secret |
+| `linear.clientId` | `LINEAR_CLIENT_ID` | Linear OAuth client ID |
+| `linear.clientSecret` | `LINEAR_CLIENT_SECRET` | Linear OAuth client secret |
+| `hermes.webhookUrl` | `HERMES_WEBHOOK_URL` | Hermes webhook endpoint |
+| `hermes.routeSecret` | `HERMES_ROUTE_SECRET` | HMAC secret for Hermes payloads |
+| `hermes.timeoutMs` | `HERMES_TIMEOUT_MS` | Request timeout (default: 30000) |
+| `botUserId` | `LINEAR_BOT_USER_ID` | Bot's Linear user ID (for self-filtering) |
+| `tokenStorePath` | — | Token file path (default: `~/.linear-gateway/token.json`) |
 
 ## Security
 
-We take input from the internet (webhooks) and send it to an LLM. That's a trust boundary that needs careful handling:
+We take input from the internet (webhooks) and send it to an LLM. That's a trust boundary:
 
-- **Webhook signatures** — every incoming webhook is verified with HMAC-SHA256. Malformed or unsigned payloads are rejected before any processing.
-- **Prompt sanitization** — user-controlled text (issue titles, descriptions, comments) is sanitized before being embedded in agent prompts. Template injection patterns like `${variable}` and `{placeholder}` are neutralized to prevent prompt template abuse.
-- **Token management** — OAuth tokens are stored with atomic write-then-rename to prevent corruption. Refresh is coalesced: concurrent requests share a single in-flight refresh promise instead of triggering multiple refresh calls.
-- **Dedup** — webhook events are deduplicated with a TTL-based map. Linear may retry delivery; we process each event at most once.
-- **No runtime dependencies** — the entire plugin runs on Node.js built-ins. No express, no axios, no lodash. Less surface area.
-- **Sensitive config** — `webhookSecret`, `clientId`, and `clientSecret` are marked as sensitive in the plugin schema and won't appear in status endpoints or logs.
+- **Webhook signatures** — HMAC-SHA256 on every incoming payload. Unsigned requests are rejected.
+- **Prompt sanitization** — user-controlled text is sanitized before embedding in agent prompts. Template injection patterns (`${var}`, `{placeholder}`) are neutralized.
+- **Token management** — atomic write-then-rename storage. Coalesced refresh: concurrent requests share one in-flight promise.
+- **Dedup** — TTL-based map. Each webhook event processed at most once.
+- **No runtime dependencies** — Node.js built-ins only. No express, no axios, no lodash.
 
-## Performance
+## Agent Tools
 
-Some things we optimized because they mattered:
+Tools the agent can call while working on an issue:
 
-- **Singleton API client** — the Linear GraphQL client is created once and reused across all requests, not instantiated per-call.
-- **Team state caching** — `updateIssueState()` caches team workflow states for 5 minutes, cutting GraphQL round-trips from 3 to 2 per status update.
-- **Concurrent webhook handling** — the dispatch context is stored per-issue, not in a global singleton, so multiple issues can be processed concurrently without race conditions.
-- **Memory cleanup** — session maps and dedup caches are cleaned up with TTL-based sweeps, not unbounded growth.
-- **Body size limits** — webhook payloads are capped at 1MB and read with a 5-second timeout to prevent resource exhaustion.
+| Tool | Description |
+|---|---|
+| `linear_update_status` | Change issue status (In Progress, Done, etc.) |
+| `linear_get_issue` | Full issue details — comments, labels, assignee, project |
+| `linear_search_issues` | Search issues by query |
+| `project_memory_save` | Save to project memory files + git commit |
 
-## Setup
+## OpenClaw Plugin Setup
 
-### One Prompt Setup
+### One-Prompt Setup
 
-Copy this prompt and paste it to your coding agent (Claude Code, Cursor, etc.):
+Paste this to your coding agent:
 
-````
+`````
 Install and configure the openclaw-linear-light plugin for my OpenClaw gateway.
 
 My setup:
@@ -123,26 +189,22 @@ My setup:
 - Linear workspace: <your-workspace-name>
 
 Steps:
-1. Clone https://github.com/QiuYi111/openclaw-linear-light
+1. Clone https://github.com/QiuYi111/linear-light
 2. Install the skill
 3. /linear-light-setup
 4. Verify: `GET https://<your-gateway-host>/linear-light/status` should return `"status": "ok"`
 ````
 
-The agent will handle the rest — OAuth app creation, config generation, token verification.
-
 ### Manual Setup
-
-If you prefer to do it yourself:
 
 1. **Create a Linear OAuth app** — Settings → API → OAuth Applications → Create new
    - Redirect URL: `https://<your-gateway-host>/linear-light/oauth/callback`
    - Webhook URL: `https://<your-gateway-host>/linear-light/webhook`
-   - Enable webhooks, subscribe to Issues and Agent Session events
+   - Subscribe to Issues and Agent Session events
 
 2. **Install the plugin**
    ```bash
-   openclaw plugins install ./openclaw-linear-light
+   openclaw plugins install ./linear-light
    openclaw gateway restart
    ```
 
@@ -166,246 +228,95 @@ If you prefer to do it yourself:
    }
    ```
 
-4. **Expose your gateway** — use Cloudflare Tunnel or ngrok:
+4. **Expose your gateway** — Cloudflare Tunnel or ngrok:
    ```bash
    cloudflared tunnel --url http://localhost:18789
    ```
 
-5. **Authorize** — visit `/linear-light/oauth/init` to start the OAuth flow
+5. **Authorize** — visit `/linear-light/oauth/init`
 
 6. **Verify** — `GET /linear-light/status` should return `"status": "ok"`
 
-## Agent Tools
-
-| Tool | Description |
-|------|-------------|
-| `linear_update_status` | Change issue status (e.g. "In Progress", "Done") |
-| `linear_get_issue` | Get full issue details — comments, labels, assignee, project |
-| `linear_search_issues` | Search issues by query |
-| `project_memory_save` | Save content to project memory files and git commit |
-
-## Configuration
-
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `enabled` | `boolean` | `true` | Disable the plugin |
-| `webhookSecret` | `string` | — | **Required.** Linear webhook signing secret |
-| `mentionTrigger` | `string` | `"Linus"` | Text that triggers the agent in comments |
-| `autoInProgress` | `boolean` | `true` | Auto-set issue to "In Progress" on agent start |
-| `completionLoopEnabled` | `boolean` | `true` | Enable periodic completion checks |
-| `completionLoopInterval` | `number` | `10` | Loop interval in minutes (minimum 1) |
-| `completionLoopMaxIterations` | `number` | `0` | Max iterations before stopping (0 = unlimited) |
-| `agentIdentity` | `string` | *(see below)* | System identity injected into agent prompts |
-| `initialResponseTemplate` | `string` | `"Received, processing {identifier}: {title}"` | Initial activity response template |
-| `linearClientId` | `string` | — | **Required for OAuth.** Linear OAuth client ID |
-| `linearClientSecret` | `string` | — | **Required for OAuth.** Linear OAuth client secret |
-| `projectMemoryEnabled` | `boolean` | `true` | Enable project-based memory persistence |
-| `projectMemoryBasePath` | `string` | `~/clawd/projects` | Base path for project directories |
-
-The default `agentIdentity` instructs the agent to act as a Linear workflow assistant (not a personal assistant), and lists the available Linear tools.
-
-## Deployment Notes
-
-### Agent Binding
-
-By default, Linear sessions run under the `main` agent. You can isolate them with a dedicated agent binding:
-
-```json
-{
-  "agents": {
-    "list": [
-      {
-        "id": "linear",
-        "name": "Linear Worker",
-        "workspace": "~/clawd",
-        "tools": { "allow": ["group:plugins"] }
-      }
-    ],
-    "bindings": [
-      { "channel": "linear", "agent": "linear" }
-    ]
-  }
-}
-```
-
-### Concurrency
-
-The default `maxConcurrent` is 4. If you expect many issues to be active simultaneously, increase it:
-
-```json
-{
-  "agents": {
-    "defaults": {
-      "maxConcurrent": 999
-    }
-  }
-}
-```
-
-## Troubleshooting
-
-### "no access token" at startup
-
-Visit `/linear-light/oauth/init` to start the OAuth flow.
-
-### Webhook returns 401
-
-Check that `webhookSecret` matches the signing secret in your Linear OAuth app settings.
-
-### Completion loop spins after gateway restart
-
-Ensure you're on a version that includes the fallback context fix ([#126](https://github.com/QiuYi111/openclaw-linear-light/pull/126)).
-
-### Health check returns "degraded"
-
-Check the `errors` and `warnings` fields in the `/linear-light/status` response for specific guidance.
-
-## Development
-
-```bash
-npm install            # install dev dependencies
-npm run lint           # biome check
-npm run typecheck      # tsc --noEmit
-npm run test           # vitest
-npm run test:coverage  # vitest with coverage (threshold: 90%)
-npm run check          # lint + typecheck + test
-```
-
-Zero runtime dependencies. TypeScript strict mode. ESM only. 95%+ test coverage.
-
-## Hermes Agent Setup
-
-[Hermes Agent](https://hermes-agent.nousresearch.com/) by Nous Research is an alternative AI agent backend with built-in learning, skills, MCP integration, and 15+ messaging platform support.
-
-### When to use Hermes
-
-- You prefer Hermes's agent capabilities (skills, memory, MCP)
-- You want multi-platform reply delivery (Telegram, Discord, Slack, etc.)
-- You want Hermes's built-in learning loop and user modeling
-
-### Prerequisites
-
-- [Hermes Agent installed](https://hermes-agent.nousresearch.com/docs/getting-started/installation) and running
-- Linear OAuth token (from OpenClaw plugin's `~/.openclaw/plugins/linear-light/token.json`)
-
-### Step 1: Add Linear API token to Hermes
-
-```bash
-# Read the token from OpenClaw's token store
-TOKEN=$(python3 -c "import json; print(json.load(open('$HOME/.openclaw/plugins/linear-light/token.json'))['accessToken'])")
-
-# Add to Hermes env
-echo "LINEAR_API_TOKEN=$TOKEN" >> ~/.hermes/.env
-```
-
-### Step 2: Install the Linear Workflow Skill
-
-Copy the skill file to Hermes's skills directory:
-
-```bash
-mkdir -p ~/.hermes/skills/linear-workflow
-cp docs/hermes-skill.md ~/.hermes/skills/linear-workflow/SKILL.md
-```
-
-The skill provides Hermes with:
-- Linear GraphQL API access via `curl` (comments, status updates, search)
-- Project memory workflow (read/write `~/clawd/projects/` files)
-- Reply formatting guidelines
-
-### Step 3: Configure Hermes Webhook
-
-In `~/.hermes/config.yaml`, add the webhook platform:
-
-```yaml
-platforms:
-  webhook:
-    enabled: true
-    extra:
-      port: 8644
-      secret: "your-hermes-webhook-secret"
-      routes:
-        linear:
-          secret: "your-hermes-webhook-secret"
-          prompt: "{prompt}"
-          skills: ["linear-workflow"]
-          deliver: "log"
-```
-
-> `deliver: "log"` because Hermes doesn't natively post to Linear.
-> The `linear-workflow` skill handles posting comments directly via the Linear GraphQL API.
-
-### Step 4: Enable Hermes Mode in OpenClaw
-
-Update your OpenClaw config:
-
-```json
-{
-  "plugins": {
-    "entries": {
-      "linear-light": {
-        "config": {
-          "enabled": true,
-          "webhookSecret": "your-linear-webhook-secret",
-          "linearClientId": "...",
-          "linearClientSecret": "...",
-          "dispatchMode": "hermes",
-          "hermes": {
-            "webhookUrl": "http://localhost:8644/webhooks",
-            "webhookSecret": "your-hermes-webhook-secret",
-            "routeName": "linear",
-            "timeoutMs": 15000
-          }
-        }
-      }
-    }
-  }
-}
-```
-
-### Step 5: Restart
-
-```bash
-hermes gateway restart
-openclaw gateway restart
-```
-
-### Step 6: Verify
-
-```bash
-# Check Hermes webhook health
-curl http://localhost:8644/health
-
-# Check plugin status
-curl http://localhost:<openclaw-port>/linear-light/status
-
-# Trigger a test — @mention the agent in a Linear issue
-```
-
-### Feature Comparison
-
-| Feature | OpenClaw Mode | Hermes Mode |
-|---|---|---|
-| HMAC-verified webhooks | ✅ | ✅ |
-| Per-issue sessions | ✅ | ✅ |
-| Real-time activity streaming | ✅ | ❌ |
-| Linear API tools | ✅ (native) | ✅ (via skill) |
-| Project memory (git) | ✅ (auto) | ✅ (via skill) |
-| Completion loop | ✅ (built-in) | ❌ (use Hermes cron) |
-| Auto In Progress | ✅ | ✅ (via skill) |
-| Multi-platform reply | ❌ | ✅ (15+) |
-| MCP integration | ❌ | ✅ |
-| Skills system | ❌ | ✅ |
-| Memory/learning | ❌ | ✅ |
-
-### Config Reference (Hermes)
+### OpenClaw Plugin Configuration
 
 | Option | Type | Default | Description |
 |---|---|---|---|
+| `enabled` | boolean | `true` | Disable the plugin |
+| `webhookSecret` | string | — | **Required.** Linear webhook signing secret |
+| `mentionTrigger` | string | `"Linus"` | Text that triggers the agent in comments |
+| `autoInProgress` | boolean | `true` | Auto-set "In Progress" on agent start |
+| `completionLoopEnabled` | boolean | `true` | Enable periodic completion checks |
+| `completionLoopInterval` | number | `10` | Loop interval in minutes (min 1) |
+| `completionLoopMaxIterations` | number | `0` | Max iterations (0 = unlimited) |
+| `agentIdentity` | string | *(see below)* | System identity for agent prompts |
+| `initialResponseTemplate` | string | `"Received, processing {identifier}: {title}"` | Initial activity response |
+| `linearClientId` | string | — | **Required for OAuth.** |
+| `linearClientSecret` | string | — | **Required for OAuth.** |
+| `projectMemoryEnabled` | boolean | `true` | Enable project memory persistence |
+| `projectMemoryBasePath` | string | `~/clawd/projects` | Base path for project directories |
 | `dispatchMode` | string | `"openclaw"` | `"openclaw"` or `"hermes"` |
 | `hermes.webhookUrl` | string | — | Hermes webhook endpoint URL |
 | `hermes.webhookSecret` | string | — | HMAC secret for Hermes payloads |
 | `hermes.routeName` | string | `"linear"` | Hermes webhook route name |
 | `hermes.timeoutMs` | number | `15000` | Request timeout in ms |
+
+## Hermes Agent Setup
+
+To use standalone mode or the Hermes dispatch mode in the OpenClaw plugin:
+
+1. **Install Hermes** — follow the [Hermes installation guide](https://hermes-agent.nousresearch.com/docs/getting-started/installation)
+
+2. **Add Linear API token** — copy from `~/.linear-gateway/token.json` to `~/.hermes/.env`:
+   ```
+   LINEAR_API_TOKEN=<token>
+   ```
+
+3. **Install the Linear Workflow Skill** — copy `docs/hermes-skill.md` to `~/.hermes/skills/linear-workflow/SKILL.md`
+
+4. **Configure Hermes webhook route** in `~/.hermes/config.yaml`:
+   ```yaml
+   platforms:
+     webhook:
+       enabled: true
+       extra:
+         port: 8644
+         secret: "your-hermes-webhook-secret"
+         routes:
+           linear:
+             secret: "your-hermes-webhook-secret"
+             prompt: "{prompt}"
+             skills: ["linear-workflow"]
+             deliver: "log"
+   ```
+
+5. **Restart both** — `hermes gateway restart` and (if using plugin mode) `openclaw gateway restart`
+
+## Development
+
+```bash
+npm install            # dev dependencies
+npm run lint           # biome check
+npm run typecheck      # tsc --noEmit
+npm run test           # vitest
+npm run test:coverage  # vitest --coverage (threshold: 90%)
+npm run check          # lint + typecheck + test
+```
+
+Zero runtime dependencies. TypeScript strict mode. ESM only. 95%+ test coverage.
+
+## Troubleshooting
+
+### "no access token" at startup
+Visit `/linear-light/oauth/init` to start the OAuth flow.
+
+### Webhook returns 401
+Check that `webhookSecret` matches the signing secret in your Linear OAuth app settings.
+
+### Completion loop spins after gateway restart
+Ensure you're on a version that includes the fallback context fix ([#126](https://github.com/QiuYi111/linear-light/pull/126)).
+
+### Watchdog reports unhealthy
+Run `linear watchdog --fix` to attempt auto-repair. Check `~/.linear-gateway/token.json` for token validity.
 
 ## Credits
 


### PR DESCRIPTION
近几次 PR merge 后，项目架构发生了较大调整，README 需要反映现状。

主要变更：

- 新增「Two Modes」章节，明确 OpenClaw Plugin 和 Standalone Gateway 两条路径
- Standalone Gateway 提升为一级部署选项（不再藏在 Hermes setup 里）
- 新增 standalone 配置表、watchdog 说明、anti-loop 保护
- Feature comparison 表重写，对齐当前实际能力
- Hermes setup 精简为 5 步（之前嵌在 OpenClaw plugin 流程里，容易误解为需要两个系统同时跑）
- Security / Agent Tools / Development 等章节保持原有风格
- 总长度从 418 行缩减到 ~280 行，去掉了冗余的架构描述

语气和风格与原 README 一致：直接、有观点、解释 why 而不只是 what。